### PR TITLE
Add graphviz (dot) as a required dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,11 @@ jobs:
         repository: FLAMEGPU/FLAMEGPU2
         path: FLAMEGPU2
 
+    # Install dependencies via apt
+    - name: Install graphviz
+      run: sudo apt -y install graphviz 
+
+    # Install API docs dependencies via apt
     - name: Install doxygen
       if: env.build_api_docs == 'ON'
       run: sudo apt -y install doxygen

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,10 @@ jobs:
         path: FLAMEGPU2
 
     # Install dependencies via apt
+    - name: Install graphviz
+      run: sudo apt -y install graphviz 
+
+    # Install API docs dependencies via apt
     - name: Install doxygen
       if: env.build_api_docs == 'ON'
       run: sudo apt -y install doxygen

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 doxyoutput/*
 xml/*
 _build/*
-build/*
+build*/*
 # This directory is created in root by Breathe for Sphinx
 src/api/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ set(SPHINX_BUILD "${CMAKE_CURRENT_BINARY_DIR}/userguide")
 set(SPHINX_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 # set(SPHINX_CAHCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_doctrees")
 
+# Find graphviz which is required for the user guide (sphinx graphviz plugin)
+find_package(Graphviz REQUIRED)
+
 find_package(FLAMEGPU2)
 # Build Doxygen if we can
 if(FLAMEGPU2_FOUND)
@@ -34,7 +37,6 @@ file(RELATIVE_PATH RELPATH_CONFIG_TO_STATIC "${SPHINX_CONFIG_DIR}" "${SPHINX_SOU
 set(EXHALE_CONTAINMENT_FOLDER_ABS "${SPHINX_SOURCE}/api")
 file(RELATIVE_PATH EXHALE_CONTAINMENT_FOLDER "${SPHINX_CONFIG_DIR}" "${EXHALE_CONTAINMENT_FOLDER_ABS}")
 
-message("FLAMEGPU2_FOUND ${FLAMEGPU2_FOUND}")
 if(FLAMEGPU2_FOUND AND DOXYGEN_FOUND)
     # Set the var used when generating conf.py to enable breathe/exhale 
     set(USE_BREATHE_EXHALE "True")

--- a/cmake/FindGraphviz.cmake
+++ b/cmake/FindGraphviz.cmake
@@ -1,0 +1,12 @@
+# @todo - expand this to actually be graphviz not just dot.
+# Look for the dot executable belonging to graphviz
+find_program(GRAPHVIZ_DOT_EXECUTABLE
+             NAMES dot
+             DOC "Path to graphviz dot executable")
+ 
+include(FindPackageHandleStandardArgs)
+ 
+# Handle standard arguments to find_package like REQUIRED and QUIET
+find_package_handle_standard_args(Graphviz
+                                  "Failed to find dot executable"
+                                  GRAPHVIZ_DOT_EXECUTABLE)

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ The FLAME GPU 2 userguide and API docs can be found at [docs.flamegpu.com](https
 ## Requirements
 * [CMake](https://cmake.org/)
 * [Python3]
+* [Graphviz](https://graphviz.org/)
 *Python Packages:*
   * [Sphinx](http://www.sphinx-doc.org/en/master/) >= 2.0
   * [Breathe](https://breathe.readthedocs.io/en/latest/) >= 4.13.0


### PR DESCRIPTION
Cmake fill fail to configure if graphviz (`dot`) cannot be found.

It should now be installed on CI 