### PR TITLE
This table had some misaligned columns, so was missing from the website.

### DIFF
--- a/src/guide/5-running-a-sim/5-configuring-execution.rst
+++ b/src/guide/5-running-a-sim/5-configuring-execution.rst
@@ -5,23 +5,23 @@ Configuring Execution
 
 The ``CUDASimulation`` instance provides a range of configuration options which can be controlled directly in code, or via the command line interface. The below table details the variables available in code, and the arguments available to the command line interface.
 
-====================== ========================== ================== ============================
-Config Variable        Long Argument              Short Argument     Description
-====================== ========================== ================== ============================
-``input_file``         ``--in <file path>``       ``-i <file path>`` Path to a JSON/XML file to read the input state (agent/environment data).
-``step_log_file``      ``--out-step <file path>`` n/a                Path to a JSON/XML file to store step logging data.
-``exit_log_file``      ``--out-exit <file path>`` n/a                Path to a JSON/XML file to store exit logging data.
-``common_log_file``    ``--out-log <file path>``  n/a                Path to a JSON/XML file to store both step and exit logging data.
-``truncate_log_files`` n/a                        n/a                If true, log files will overwrite any pre-existing file with the same path/name. Default value true.
-``random_seed``        ``--random <int>``         ``-r <int>``       Random seed. Default value is sample from the clock (e.g. it will change each run).
-``steps``              ``--steps <int>``          ``-s <int>``       Number of simulation steps to execute. 0 will run indefinitely, or until an exit function causes the simulation to end. Default value 1.    
-``verbose``             ``--verbose``             ``-v``             Enable verbose simulation output to console. Default value false.
-``timing``              ``--timing``              ``-t``             Output simulation timing detail to console. Default value false.
-``console_mode``        ``--console``             ``-c``             Visualisation builds only, disable the visualisation. Default value false.
-``device_id``           ``--device <device id>``  ``-d <device id>`` The CUDA device id of the GPU to use. Default value 0 (Note this is found within ``CUDAConfig()``)
-``inLayerConcurrency``  n/a                       n/a                Enables the use of concurrency within layers. Default value true. (Note this is found within ``CUDAConfig()``)
-n/a                     ``--help``                ``-h`              Print help for the command line interface and exit
-======================= ========================= ================== ============================
+======================= ========================== ================== ====================================================================================
+Config Variable         Long Argument              Short Argument     Description
+======================= ========================== ================== ====================================================================================
+``input_file``          ``--in <file path>``       ``-i <file path>`` Path to a JSON/XML file to read the input state (agent/environment data).
+``step_log_file``       ``--out-step <file path>`` n/a                Path to a JSON/XML file to store step logging data.
+``exit_log_file``       ``--out-exit <file path>`` n/a                Path to a JSON/XML file to store exit logging data.
+``common_log_file``     ``--out-log <file path>``  n/a                Path to a JSON/XML file to store both step and exit logging data.
+``truncate_log_files``  n/a                        n/a                If true, log files will overwrite any pre-existing file with the same path/name. Default value true.
+``random_seed``         ``--random <int>``         ``-r <int>``       Random seed. Default value is sample from the clock (e.g. it will change each run).
+``steps``               ``--steps <int>``          ``-s <int>``       Number of simulation steps to execute. 0 will run indefinitely, or until an exit function causes the simulation to end. Default value 1.    
+``verbose``             ``--verbose``              ``-v``             Enable verbose simulation output to console. Default value false.
+``timing``              ``--timing``               ``-t``             Output simulation timing detail to console. Default value false.
+``console_mode``        ``--console``              ``-c``             Visualisation builds only, disable the visualisation. Default value false.
+``device_id``           ``--device <device id>``   ``-d <device id>`` The CUDA device id of the GPU to use. Default value 0 (Note this is found within ``CUDAConfig()``)
+``inLayerConcurrency``  n/a                        n/a                Enables the use of concurrency within layers. Default value true. (Note this is found within ``CUDAConfig()``)
+n/a                     ``--help``                 ``-h``             Print help for the command line interface and exit
+======================= ========================== ================== ====================================================================================
 
 In order for the command line arguments to be processed ``argc`` and ``argv`` must be passed to ``initialise()``. An example of this is shown below.
 


### PR DESCRIPTION
There should be a table after the first paragraph here: https://docs.flamegpu.com/guide/5-running-a-sim/5-configuring-execution.html

There isn't.

This PR fixes it:

![image](https://user-images.githubusercontent.com/742154/152833734-9f341b42-4445-497f-b5dc-bb6314d5fa36.png)
