### PR TITLE
Update docs for Py API breaking changes.

### DIFF
--- a/src/guide/environment/index.rst
+++ b/src/guide/environment/index.rst
@@ -63,10 +63,10 @@ The type, name and initial value of the property are all specified, array proper
     # Declare an int property named 'foo', with a default value 12
     env.newPropertyInt("foo", 12)
     # Declare a float array property of length 3 named 'bar', with a default value [4.0, 5.0, 6.0]
-    env.newPropertyArrayFloat("bar", 3, [4.0, 5.0, 6.0])
+    env.newPropertyArrayFloat("bar", [4.0, 5.0, 6.0])
 
 .. note::
-  Under the C/C++ API, the type and array length arguments are specified via template args. Under the Python API, the type is included in the method's identifier, and the array length is passed as an argument to the function. This pattern is a consistent difference between the two APIs.
+  Under the C/C++ API, the type and array length arguments are specified via template args. Under the Python API, the type is included in the method's identifier, and the array length is normally not required to be explicitly specified. This pattern is a consistent difference between the two APIs, however code in agent functions follow the C/C++ format.
 
 .. note:
   

--- a/src/guide/running-multiple-simulations/index.rst
+++ b/src/guide/running-multiple-simulations/index.rst
@@ -71,6 +71,9 @@ It is also possible to specify subdirectories for a particular runs' logging out
         // Initialise environment property 'random_double' with values from the log normal dist (mean: 2, stddev: 1)
         runs_control.setPropertyLogNormalRandom<double>("random_double", 2.0, 1.0);
         
+        // Initialise environment property array 'int_array_3' with [1, 3, 5]
+        runs_control.setProperty<int, 3>("int_array_3", {1, 3, 5});
+        
         // Iterate vector to manually assign properties
         for (RunPlan &plan:runs_control) {
             // e.g. manually set all 'manual_float' to 32
@@ -103,12 +106,17 @@ It is also possible to specify subdirectories for a particular runs' logging out
     runs_control.setRandomSimulationSeed(12, 1)
     # Initialise environment property 'lerp_float' with values uniformly distributed between 1 and 128
     runs_control.setPropertyUniformDistributionFloat("lerp_float", 1.0, 128.0)
+    
     # Initialise environment property 'random_int' with values uniformly distributed in the range [0, 10]
     runs_control.setPropertyUniformRandomInt("random_int", 0, 10)
     # Initialise environment property 'random_float' with values from the normal dist (mean: 1, stddev: 2)
     runs_control.setPropertyNormalRandomFloat("random_float", 1.0, 2.0)
     # Initialise environment property 'random_double' with values from the log normal dist (mean: 2, stddev: 1)
     runs_control.setPropertyLogNormalRandomDouble("random_double", 2.0, 1.0)
+    
+    # Initialise environment property array 'int_array_3' with [1, 3, 5]
+    runs_control.setPropertyArrayInt("int_array_3", (1, 3, 5))
+    
     # Iterate vector to manually assign properties
     for plan in runs_control:
         # e.g. manually set all 'manual_float' to 32


### PR DESCRIPTION
Noticed there wasn't actually an example of `RunPlan`/`RunPlanVector`, so added one.

Haven't tested the code examples (because they're incomplete), but they match the updated test cases which were tested.

See https://github.com/FLAMEGPU/FLAMEGPU2/pull/859