### PR TITLE
Bugfix 2022 06 16

### DIFF
--- a/src/guide/agent-functions/interacting-with-environment.rst
+++ b/src/guide/agent-functions/interacting-with-environment.rst
@@ -94,6 +94,9 @@ Example usage is shown below:
         ...
     }
     
+.. warning::
+  Be careful when using :class:`DeviceMacroProperty<flamegpu::DeviceMacroProperty>`. When you retrieve an element e.g. ``location[0][0][0]`` (from the example above), it is of type :class:`DeviceMacroProperty<flamegpu::DeviceMacroProperty>` not ``unsigned int``. Therefore you cannot pass it directly to functions which take generic arguments such as ``printf()``, as it will be interpreted incorrectly. You must either store it in a variable of the correct type which you instead pass, or explicitly cast it to the correct type when passing it e.g. ``(unsigned int)location[0][0][0]`` or ``static_cast<unsigned int>(location[0][0][0])``.
+    
     
 Related Links
 -------------

--- a/src/guide/host-functions/interacting-with-environment.rst
+++ b/src/guide/host-functions/interacting-with-environment.rst
@@ -136,6 +136,9 @@ Below are several examples of how environment macro properties can be updated in
       bar[0][0][0]+= 1;
       bar[0][1][0] = 5;
       bar[0][0][2]+= 1; # Python does not allow the increment operator to be overridden
+      
+.. warning::
+  Be careful when using :class:`HostMacroProperty<flamegpu::HostMacroProperty>` via the C++ API. When you retrieve an element e.g. ``bar[0][0][0]`` (from the example above), it is of type :class:`HostMacroProperty<flamegpu::HostMacroProperty>` not ``int``. Therefore you cannot pass it directly to functions which take generic arguments such as ``printf()``, as it will be interpreted incorrectly. You must either store it in a variable of the correct type which you instead pass, or explicitly cast it to the correct type when passing it e.g. ``(int)bar[0][0][0]`` or ``static_cast<int>(bar[0][0][0])``.
     
 Related Links
 -------------

--- a/src/guide/host-functions/interacting-with-environment.rst
+++ b/src/guide/host-functions/interacting-with-environment.rst
@@ -11,7 +11,7 @@ The :class:`HostEnvironment<flamegpu::HostEnvironment>` instance can be accessed
 Environment Properties
 ----------------------
 
-Host functions can both read and update environment properties using :func:`setProperty()<flamegpu::HostEnvironment::setProperty>` and :func:'getProperty()<flamegpu::HostEnvironment::getProperty>' respectively.
+Host functions can both read and update environment properties using :func:`setProperty()<flamegpu::HostEnvironment::setProperty>` and :func:`getProperty()<flamegpu::HostEnvironment::getProperty>` respectively.
 
 Unlike agent functions, host functions are able to access environment property arrays in a single transaction, rather than individually accessing each element. Otherwise, the syntax matches that found in agent functions.
 


### PR DESCRIPTION
Two Changes:
* Fix a dead link in host environment
* Add a warning to host and device macro properties, that they won't work if passed directly to `printf()`. This caught out Carlos and I out, I forgot that they wouldn't work when I first tried to debug his code (where he was printing them and they were coming out 0). Very easy mistake to make.