### PR TITLE
Fix broken reference in tutorial on CMake configuration

### DIFF
--- a/src/tutorial/index.rst
+++ b/src/tutorial/index.rst
@@ -100,7 +100,7 @@ FLAME GPU 2 uses CMake to manage the build process, so we use CMake to generate 
 
 The basic commands required differ slightly between Linux and Windows, however in both cases they should be executed in the directory which the template was cloned into:
 
-*A more detailed guide, regarding building FLAME GPU 2 from source can be found :ref:`here<q-compiling flamegpu>`.*
+A more detailed guide, regarding building FLAME GPU 2 from source can be found :ref:`here<q-compiling flamegpu>`.
 
 .. tabs::
 


### PR DESCRIPTION
This is due to use of a ref inside italisciesed text (invalid rst)

Closes #96