### PR TITLE
Create api docs inside the build dir, not src

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE INTERNAL "" FORCE)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sphinx REQUIRED)
 
-set(SPHINX_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(SPHINX_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/src")
 set(SPHINX_BUILD "${CMAKE_CURRENT_BINARY_DIR}/userguide")
-set(SPHINX_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set(SPHINX_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/src")
 # set(SPHINX_CAHCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_doctrees")
 
 # Find graphviz which is required for the user guide (sphinx graphviz plugin)
@@ -30,6 +30,61 @@ if(FLAMEGPU2_FOUND)
     mark_as_advanced(FORCE BUILD_API_DOCUMENTATION)
 endif()
 
+# Define the list of known docs source files, so they can be copied into the build directory. 
+# Globbing is not viable as adding new files would not trigger a new incremental build.
+# Does not include .in files, which are managed separately.
+set(DOCS_SRC_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/agent-birth-death.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/agent-communication.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/conditional-behaviours.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/defining-agent-functions.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/interacting-with-environment.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/miscellaneous.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/modifying-agent-variables.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/agent-functions/random-numbers.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/creating-a-model/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/defining-agents/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/defining-execution-order/dependency-graph.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/defining-execution-order/exit-conditions.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/defining-execution-order/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/defining-execution-order/layers.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/defining-execution-order/submodels.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/defining-messages-communication/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/environment/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/flamegpu2-source/build-from-source.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/flamegpu2-source/contribute.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/flamegpu2-source/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/flamegpu2-source/request-a-new-feature.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/host-functions/agent-operations.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/host-functions/defining-host-functions.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/host-functions/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/host-functions/interacting-with-environment.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/host-functions/miscellaneous.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/host-functions/random-numbers.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/performance-troubleshooting/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/running-a-simulation/collecting-data.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/running-a-simulation/configuring-execution.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/running-a-simulation/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/running-a-simulation/initial-state.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/running-multiple-simulations/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/seatbelts/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/visualisation/adding-details.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/visualisation/building-with-vis.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/visualisation/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/visualisation/setting-up-vis.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/visualisation/visualisation-controls.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/guide/visualisation/visualising-agents.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/quickstart/cmake-generator.png"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/quickstart/cmake-gui-annotated.png"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/quickstart/cmake-gui.png"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/quickstart/index.rst"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/_static/css/flamegpu.css"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/_static/img/flamegpu2-icon-notext-128.png"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/tutorial/index.rst"
+)
+
 # Get the relative path to the SRC directory from the current build directory
 file(RELATIVE_PATH RELPATH_CONFIG_TO_STATIC "${SPHINX_CONFIG_DIR}" "${SPHINX_SOURCE}/_static")
 
@@ -37,48 +92,88 @@ file(RELATIVE_PATH RELPATH_CONFIG_TO_STATIC "${SPHINX_CONFIG_DIR}" "${SPHINX_SOU
 set(EXHALE_CONTAINMENT_FOLDER_ABS "${SPHINX_SOURCE}/api")
 file(RELATIVE_PATH EXHALE_CONTAINMENT_FOLDER "${SPHINX_CONFIG_DIR}" "${EXHALE_CONTAINMENT_FOLDER_ABS}")
 
+# Add custom commands to copy each listed source file from the source directory into the build directory. To fix true out-of-tree builds.
+set(BUILD_SRC_DEPENDS)
+foreach(SRC_FILE IN LISTS DOCS_SRC_FILES)
+    file(RELATIVE_PATH SRC_FILE_CLEAN "${CMAKE_CURRENT_SOURCE_DIR}" "${SRC_FILE}")
+    set(BUILD_SRC_FILE "${CMAKE_CURRENT_BINARY_DIR}/${SRC_FILE_CLEAN}")
+    add_custom_command(
+        OUTPUT  ${BUILD_SRC_FILE}
+        DEPENDS ${SRC_FILE} ${CMAKE_CURRENT_BINARY_DIR}/src/index.rst
+        COMMAND ${CMAKE_COMMAND} -E copy ${SRC_FILE} ${BUILD_SRC_FILE}
+        COMMENT "Copying ${SRC_FILE} to ${BUILD_SRC_FILE}"
+    )
+    list(APPEND BUILD_SRC_DEPENDS "${BUILD_SRC_FILE}")
+    unset(BUILD_SRC_FILE)
+    unset(SRC_FILE_CLEAN)
+endforeach()
+
 if(FLAMEGPU2_FOUND AND DOXYGEN_FOUND AND ${BUILD_API_DOCUMENTATION})
     # Set the var used when generating conf.py to enable breathe/exhale 
     set(USE_BREATHE_EXHALE "True")
+    set(EXCLUDE_API_PATTERN "") # Do not exlude the api dir
     # Decide path to temp store the xml output, used in conf.py generation.
     set(API_DOCS_XML_PATH "api_xml")
-
     # Generate conf.py in the build directory
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/conf.py.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/conf.py"
+        "${CMAKE_CURRENT_BINARY_DIR}/src/conf.py"
         @ONLY
     )
+    list(APPEND BUILD_SRC_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/src/conf.py")
+    unset(USE_BREATHE_EXHALE)
+    unset(EXCLUDE_API_PATTERN)
+    set(API_TOC_PATH "api/library_root")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/index.rst.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/src/index.rst"
+        @ONLY
+    )
+    list(APPEND BUILD_SRC_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/src/index.rst")
+    unset(API_TOC_PATH)
 
     # Create Doxygen target 'userguide_docs_xml'
-    create_doxygen_target("${FLAMEGPU_ROOT}" "${CMAKE_CURRENT_BINARY_DIR}" "${API_DOCS_XML_PATH}")
+    create_doxygen_target("${FLAMEGPU_ROOT}" "${CMAKE_CURRENT_BINARY_DIR}" "src/${API_DOCS_XML_PATH}")
     # Create Sphinx target
     add_custom_target(userguide ALL
         COMMAND ${SPHINX_EXECUTABLE} -b html
         -c "${SPHINX_CONFIG_DIR}"
         ${SPHINX_SOURCE} ${SPHINX_BUILD}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        BYPRODUCTS ${EXHALE_CONTAINMENT_FOLDER_ABS} ${SPHINX_BUILD}
+        BYPRODUCTS ${EXHALE_CONTAINMENT_FOLDER_ABS} ${SPHINX_BUILD} ${CMAKE_CURRENT_BINARY_DIR}/src/conf.py
+        DEPENDS ${BUILD_SRC_DEPENDS}
         )
     # Make Sphinx target depend on Doxygen target
     add_dependencies(userguide api_docs_xml)
 else()
     # Set the var used when generating conf.py to disable breathe/exhale 
     set(USE_BREATHE_EXHALE "False")
+    # exclude the api dir via pattern in the conf.py incase it exists.
+    set(EXCLUDE_API_PATTERN ", 'api'")
     # Generate conf.py in the build directory
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/conf.py.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/conf.py"
+        "${CMAKE_CURRENT_BINARY_DIR}/src/conf.py"
         @ONLY
     )
+    list(APPEND BUILD_SRC_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/src/conf.py")
+    unset(USE_BREATHE_EXHALE)
+    unset(EXCLUDE_API_PATTERN)
+    set(API_TOC_PATH "") # set the include line to the emtpy str
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/index.rst.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/src/index.rst"
+        @ONLY
+    )
+    list(APPEND BUILD_SRC_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/src/index.rst")
+    unset(API_TOC_PATH)
     # Create the custom target with appropriate command.
     add_custom_target(userguide ALL
         COMMAND ${SPHINX_EXECUTABLE} -b html
         -c "${SPHINX_CONFIG_DIR}"
         ${SPHINX_SOURCE} ${SPHINX_BUILD}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        BYPRODUCTS ${SPHINX_BUILD}
+        BYPRODUCTS ${SPHINX_BUILD} ${CMAKE_CURRENT_BINARY_DIR}/src/conf.py
+        DEPENDS ${BUILD_SRC_DEPENDS}
     )
 endif()
-
-# @todo - api docs .RST should not be built into the src dir - they are part of the build (and should be in the build dir). **But** EXHALE_CONTAINMENT_FOLDER **must** be a child of SPHINX_SOURCE. Probably either need to copy src/ into build, and use that as the sphinx source, or do soemthing with symlinks? Either option is grim.

--- a/src/conf.py.in
+++ b/src/conf.py.in
@@ -102,7 +102,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store'@EXCLUDE_API_PATTERN@]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/src/index.rst.in
+++ b/src/index.rst.in
@@ -13,7 +13,7 @@ Welcome to FLAME GPU 2's documentation!
    tutorial/index.rst
    quickstart/index.rst
    guide/index.rst
-   api/library_root
+   @API_TOC_PATH@
    Forum <https://github.com/FLAMEGPU/FLAMEGPU2/discussions>
 
 


### PR DESCRIPTION
Closes #5

CMake requires an explicit list of src/ files to be copied into build. This does not include .in files which are manually configured.

Copies src into build/src, configures .in files into build/src too
exhale/breathe builds into build/src/api rather than src/api
runs sphinx from build/src, producing userguide into the same location build/userguide

allows the same build directory to be used for BUILD_API_DOCUMENTATION=OFF after being used to generate the api docs, but it won't include the api docs in the generated output.

Also possible to now have multiple build directories, with BUILD_API_DOCUMENTAION on/off that do not conflict with one another.

---

This probably won't conflict with active branches, but post-merge the output may be incorrect if files have been created / deleted not present in `HEAD~1` of this branch. 

I.e. changes will be required, with the apporpirate location depending on merge order.