### PR TITLE
Documentation for pure Python device interface

### DIFF
--- a/src/guide/agent-functions/agent-birth-death.rst
+++ b/src/guide/agent-functions/agent-birth-death.rst
@@ -32,11 +32,11 @@ the :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` object
 Killing Agents via Agent Functions
 ==================================
 
-To have an agent die, simply return :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` instead of :enumerator:`flamegpu::ALIVE<flamegpu::AGENT_STATUS::ALIVE>` at the end of a death-enabled agent function. You can use conditionals to only have agents die according to a certain condition:
+To have an agent die, simply return :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` (``pyflamegpu.DEAD`` in Python) instead of :enumerator:`flamegpu::ALIVE<flamegpu::AGENT_STATUS::ALIVE>` (``pyflamegpu.ALIVE`` in Python) at the end of a death-enabled agent function. You can use conditionals to only have agents die according to a certain condition:
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
     
     FLAMEGPU_AGENT_FUNCTION(agent_fn1, flamegpu::MessageNone, flamegpu::MessageNone) {
         // Get the 'x' variable of the agent
@@ -50,14 +50,27 @@ To have an agent die, simply return :enumerator:`flamegpu::DEAD<flamegpu::AGENT_
         }
     }
 
+  .. code-tab:: py Agent Python
+    
+    @pyflamegpu.agent_function
+    def agent_fn1(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageNone):
+        # Get the 'x' variable of the agent
+        x = pyflamegpu.getVariableInt("x")
+        
+        # Kill any agents with x < 25
+        if (x < 25) :
+            return pyflamegpu.DEAD
+        else :
+            return pyflamegpu.ALIVE
 
-If :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` is returned by an agent function whilst agent death is not enabled the agent will not die. If ``SEATBELTS`` error checking is enabled an exception will be raised.
+
+If :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` (``pyflamegpu.DEAD`` in Python) is returned by an agent function whilst agent death is not enabled the agent will not die. If ``SEATBELTS`` error checking is enabled an exception will be raised.
 
 
 Agent Birth
 -----------
 The agent creation interface usable in agent functions is only able to create a single agent per existing agent per iteration. 
-Additionally, the  type (and state) of the agent being created must be earlier specified as part of the model description (a single agent function can only output 1 specific agent type and state). Agent's can also be created via host functions, that may be more applicable in cases where many agents must be created from a single source.
+Additionally, the  type (and state) of the agent being created must be earlier specified as part of the model description (a single agent function can only output one specific agent type and state). Agent's can also be created via host functions, that may be more applicable in cases where many agents must be created from a single source.
 
 Agent birth from agent functions is always considered optional, any agent which sets an output agent's variables will cause the output agent to be created.
 
@@ -104,7 +117,7 @@ To create agents from agent functions, you must specify the type of agent the fu
 Creating Agents via Agent Functions
 ===================================
 
-When agent output has been enabled for an agent function, the :class:`FLAMEGPU->agent_out<flamegpu::DeviceAPI::AgentOut>` object will become available within agent
+When agent output has been enabled for an agent function, the :class:`FLAMEGPU->agent_out<flamegpu::DeviceAPI::AgentOut>` (``pyflamegpu.agent_out`` in Python) object will become available within agent
 function definitions. This can be used to initialise the properties of the newly created agent.
 
 Much like the agent's variables, :func:`setVariable()<flamegpu::DeviceAPI::AgentOut::setVariable>` can be used on this object, to set the new agent's variables. Additionally, :func:`getID()<flamegpu::DeviceAPI::AgentOut::getID>` may be used to retrieve the new agents future ID.
@@ -115,7 +128,7 @@ Agent creation is always optional once enabled, a new agent will only be marked 
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
   
     FLAMEGPU_AGENT_FUNCTION(OptionalOutput, flamegpu::MessageNone, flamegpu::MessageNone) {
         // Fetch this agent's id
@@ -130,6 +143,21 @@ Agent creation is always optional once enabled, a new agent will only be marked 
         // Other agent function code
         ...
     }
+
+  .. code-tab:: py Agent Python
+  
+    @pyflamegpu.agent_function
+    def OptionalOutput(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageNone):
+        # Fetch this agent's id
+        id = pyflamegpu.getID()
+  
+        # If its id is even, output a new agent, otherwise do nothing
+        if id % 2 == 0 :
+            # Output a new agent with its 'x' variable set to 500.0f
+            pyflamegpu.agent_out.setVariableFloat("x", 500.0f)
+  
+        # Other agent function code
+        ...
 
 If :class:`FLAMEGPU->agent_out<flamegpu::DeviceAPI::AgentOut>` is used in an agent function which has not had agent output enabled, no agent will be created. If ``SEATBELTS`` error checking is enabled, an exception will be raised.
 

--- a/src/guide/agent-functions/agent-communication.rst
+++ b/src/guide/agent-functions/agent-communication.rst
@@ -13,12 +13,22 @@ Messages can be output by agent functions. Each agent function can output a sing
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageBruteForce" communication strategy
       FLAMEGPU_AGENT_FUNCTION(outputdata, flamegpu::MessageNone, flamegpu::MessageBruteForce) {
           // Agent function code goes here
+          ...
       }
+
+
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageBruteForce" communication strategy
+      @pyflamegpu.agent_function
+      def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageBruteForce):
+          # Agent function code goes here
+          ...
 
 To specify the type of message the function should output, the :func:`setMessageOutput()<flamegpu::AgentFunctionDescription::setMessageOutput>` method of the :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` object is used:
 
@@ -52,7 +62,7 @@ The agent function will now allow output a message of type "location_message". T
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageBruteForce" communication strategy
       FLAMEGPU_AGENT_FUNCTION(outputdata, flamegpu::MessageNone, flamegpu::MessageBruteForce) {
@@ -60,6 +70,16 @@ The agent function will now allow output a message of type "location_message". T
           FLAMEGPU->message_out.setVariable<flamegpu::id_t>("id", FLAMEGPU->getID());
           return flamegpu::ALIVE;
       }
+
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageBruteForce" communication strategy
+      @pyflamegpu.agent_function
+      def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageBruteForce):
+          # Set the "id" message variable to this agent's id (ID type is equivalent to an unsigned int within Python)
+          pyflamegpu.message_out.setVariableUInt("id", pyflamegpu.getID())
+          return pyflamegpu.ALIVE
+
       
 Specialised message types have additional output values which must be provided. These are detailed in the following sub sections.
 
@@ -72,7 +92,7 @@ When outputting bucket messages, the bucket index for the message must be set, u
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageBucket" communication strategy
       FLAMEGPU_AGENT_FUNCTION(outputdata, flamegpu::MessageNone, flamegpu::MessageBucket) {
@@ -81,6 +101,16 @@ When outputting bucket messages, the bucket index for the message must be set, u
           FLAMEGPU->message_out.setKey(FLAMEGPU->getVariable<int>("bucket"));
           return flamegpu::ALIVE;
       }
+
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageBucket" communication strategy
+      @pyflamegpu.agent_function
+      def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageBruteForce):
+          pyflamegpu.message_out.setVariableFloat("x", pyflamegpu.getVariableFloat("x"))
+          # Set the bucket key for the message, to the agents "bucket" member variable
+          pyflamegpu.message_out.setKey(pyflamegpu.getVariableInt("bucket"))
+          return pyflamegpu.ALIVE
       
 Messages assigned keys outside of the bounds have undefined behaviour. If using ``SEATBELTS`` error checking, an exception will be raised.
 
@@ -91,7 +121,7 @@ If you are using :class:`MessageSpatial2D<flamegpu::MessageSpatial2D>` or :class
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageSpatial3D" communication strategy
       FLAMEGPU_AGENT_FUNCTION(outputdata, flamegpu::MessageNone, flamegpu::MessageSpatial3D) {
@@ -104,6 +134,19 @@ If you are using :class:`MessageSpatial2D<flamegpu::MessageSpatial2D>` or :class
           return flamegpu::ALIVE;
       }
       
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageSpatial3D" communication strategy
+      @pyflamegpu.agent_function
+      def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageSpatial3D):
+          # Set the required variables for spatial messaging
+          pyflamegpu.message_out.setVariableFloat("x", pyflamegpu.getVariableFloat("x"))
+          pyflamegpu.message_out.setVariableFloat("y", pyflamegpu.getVariableFloat("y"))
+          pyflamegpu.message_out.setVariableFloat("z", pyflamegpu.getVariableFloat("z"))
+          # Set any tertiary message variables
+          pyflamegpu.message_out.setVariableInt("count", pyflamegpu.getVariableInt("count"))
+          return pyflamegpu.ALIVE
+
 Array Messaging
 ===============
 
@@ -111,7 +154,7 @@ If you are using :class:`MessageArray<flamegpu::MessageArray>`, :class:`MessageA
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageArray3D" communication strategy
       FLAMEGPU_AGENT_FUNCTION(outputdata, flamegpu::MessageNone, flamegpu::MessageArray3D) {
@@ -122,6 +165,17 @@ If you are using :class:`MessageArray<flamegpu::MessageArray>`, :class:`MessageA
           return flamegpu::ALIVE;
       }
 
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageArray3D" communication strategy
+      @pyflamegpu.agent_function
+      def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageArray3D):
+          # Set the index to store the array message
+          pyflamegpu.message_out.setIndex(pyflamegpu.getVariableUInt("x"), pyflamegpu.getVariableUInt("y"), pyflamegpu.getVariableUInt("z"))
+          # Set message variables
+          pyflamegpu.message_out.setVariableFloat("foo", pyflamegpu.getVariableFloat("bar"))
+          return pyflamegpu.ALIVE
+
 Reading Messages
 ----------------
 
@@ -129,13 +183,21 @@ Reading a message is very similar to sending one. The second argument in the age
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "inputdata" which has an input message using the "MessageBruteForce" communication strategy
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageBruteForce, flamegpu::MessageNone) {
           // Agent function code goes here
           ...
       }
+
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "inputdata" which has an input message using the "MessageBruteForce" communication strategy
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageBruteForce, message_out: pyflamegpu.MessageNone):
+          # Agent function code goes here
+          ...
 
 To specify the type of message the function should input, the :func:`setMessageInput()<flamegpu::AgentFunctionDescription::setMessageInput>` method of the :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` object is used:
 
@@ -162,7 +224,7 @@ All messages are accessed, so the whole message list is iterated over:
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "inputdata" which has an input message using the "MessageBruteForce" communication strategy
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageBruteForce, flamegpu::MessageNone) {
@@ -175,6 +237,18 @@ All messages are accessed, so the whole message list is iterated over:
           ...
       }
 
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "inputdata" which has an input message using the "MessageBruteForce" communication strategy
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageBruteForce, message_out: pyflamegpu.MessageNone):
+          # For each message in the message list 
+          for message in pyflamegpu.message_in:
+              # Process the message's variables e.g.
+              # var = message.getVariableInt(...)
+              ...
+          ...
+
 Bucket Messaging
 ================
 
@@ -184,7 +258,7 @@ If an invalid bucket key is specified (based on the bounds provided when the mes
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
 
     // Define an agent function, "inputdata" which has an input message using the "MessageBucket" communication strategy
     FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageBucket, flamegpu::MessageNone) {
@@ -200,6 +274,21 @@ If an invalid bucket key is specified (based on the bounds provided when the mes
         ...
     }
 
+  .. code-tab:: py Agent Python
+
+      # Define an agent function, "inputdata" which has an input message using the "MessageBucket" communication strategy
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageBucket, message_out: pyflamegpu.MessageNone):
+          # Get this agent's bucket variable
+          x = pyflamegpu.getVariableInt("bucket");
+
+          # For each message in the message list which was output to the requested bucket
+          for message in pyflamegpu.message_in(bucket):
+              # Process the message's variables e.g.
+              # var = message.getVariableInt(...)
+              ...
+          ...
+
 Spatial Messaging
 =================
 If you are using one of the spatial messaging strategies, you will also need to supply the x, y (and z) coordinates of the agent, or the central location about which you wish to access messages.
@@ -208,7 +297,7 @@ Spatial messaging will return all messages within the radius specified at the mo
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
       // Define an agent function, "inputdata" which has accepts an input message using the "MessageSpatial3D" communication strategy
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageSpatial3D, flamegpu::MessageNone) {
@@ -236,6 +325,33 @@ Spatial messaging will return all messages within the radius specified at the mo
           }
           ...
       }
+
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "inputdata" which has an input message using the "MessageSpatial3D" communication strategy
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageSpatial3D, message_out: pyflamegpu.MessageNone):
+          RADIUS = pyflamegpu.message_in.radius()
+          # Get this agent's x, y, z variables
+          x = pyflamegpu.getVariableFloat("x")
+          y = pyflamegpu.getVariableFloat("y")
+          z = pyflamegpu.getVariableFloat("z")
+          
+          # For each message in the message list which was output by a nearby agent
+          for message in pyflamegpu.message_in(x, y, z):
+              x2 = message.getVariableFloat("x")
+              y2 = message.getVariableFloat("y")
+              z2 = message.getVariableFloat("z")
+              # Calculate the distance to check the message is in range
+              x21 = x2 - x1
+              y21 = y2 - y1
+              z21 = z2 - z1
+              separation = math.cbrt(x21*x21 + y21*y21 + z21*z21)
+              if separation < RADIUS and separation > 0 :
+                  # Process the message's variables e.g.
+                  # var = message.getVariableInt(...)
+                  ...
+          ...
       
 .. note::
     Spatial messaging does not return messaging wrapping the environment bounds.
@@ -248,9 +364,9 @@ Messages can be accessed from a specific array index:
 
 .. tabs::
 
-    .. code-tab:: cuda CUDA C++
+    .. code-tab:: cuda Agent C++
 
-      // Define an agent function, "inputdata" which has accepts an input message using the "MessageSpatial3D" communication strategy and inputs no messages
+      // Define an agent function, "inputdata" which has accepts an input message using the "MessageArray3D" communication strategy and inputs no messages
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageArray3D, flamegpu::MessageNone) {
           // Get this agent's x, y, z variables
           const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
@@ -262,21 +378,36 @@ Messages can be accessed from a specific array index:
           // const T var = message.getVariable<T>(...);
           ...
       }
+
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "inputdata" which has an input message using the "MessageArray3D" communication strategy
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageArray3D, message_out: pyflamegpu.MessageNone):
+          # Get this agent's x, y, z variables
+          x = pyflamegpu.getVariableFloat("x")
+          y = pyflamegpu.getVariableFloat("y")
+          z = pyflamegpu.getVariableFloat("z")
+          # Select the message
+          message = pyflamegpu.message_in.at(x, y, z)
+          # Process the message's variables e.g.
+          # var = message.getVariableInt(...)
+          ...
       
 
 Similar to spatial messaging, array messages provide several iterators for accessing a collection of messages localised to a specific location (normally a discrete agent's position). ``operator()`` (:func:`1D<flamegpu::MessageArray::In::operator()>`, :func:`2D<flamegpu::MessageArray2D::In::operator()>`, :func:`3D<flamegpu::MessageArray3D::In::operator()>`):
 
 
-================================= =============================================== ==================================
-Iterator                          Usage                                           API Docs
-================================= =============================================== ==================================
-Moore Neighbourhood               ``FLAMEGPU->message_in(<arguments>)``           :func:`1D<flamegpu::MessageArray::In::operator()>`, :func:`2D<flamegpu::MessageArray2D::In::operator()>`, :func:`3D<flamegpu::MessageArray3D::In::operator()>`
-Wrapped Moore Neighbourhood       ``FLAMEGPU->message_in.wrap(<arguments>)``      :func:`1D<flamegpu::MessageArray::In::wrap()>`, :func:`2D<flamegpu::MessageArray2D::In::wrap()>`, :func:`3D<flamegpu::MessageArray3D::In::wrap()>`
-Von Neumann Neighbourhood         ``FLAMEGPU->message_in.vn(<arguments>)``        :func:`2D<flamegpu::MessageArray2D::In::vn()>`, :func:`3D<flamegpu::MessageArray3D::In::vn()>`
-Wrapped Von Neumann Neighbourhood ``FLAMEGPU->message_in.vn_wrap(<arguments>)``   :func:`2D<flamegpu::MessageArray2D::In::vn_wrap()>`, :func:`3D<flamegpu::MessageArray3D::In::vn_wrap()>`
-================================= =============================================== ==================================
+================================= =============================================== =============================================== ==================================
+Iterator                          Agent C++ Usage                                 Agent Python Usage                              API Docs
+================================= =============================================== =============================================== ==================================
+Moore Neighbourhood               ``FLAMEGPU->message_in(<arguments>)``           ``message_in(<arguments>)``                     :func:`1D<flamegpu::MessageArray::In::operator()>`, :func:`2D<flamegpu::MessageArray2D::In::operator()>`, :func:`3D<flamegpu::MessageArray3D::In::operator()>`
+Wrapped Moore Neighbourhood       ``FLAMEGPU->message_in.wrap(<arguments>)``      ``message_in.wrap(<arguments>)``                :func:`1D<flamegpu::MessageArray::In::wrap()>`, :func:`2D<flamegpu::MessageArray2D::In::wrap()>`, :func:`3D<flamegpu::MessageArray3D::In::wrap()>`
+Von Neumann Neighbourhood         ``FLAMEGPU->message_in.vn(<arguments>)``        ``message_in.vn(<arguments>)``                  :func:`2D<flamegpu::MessageArray2D::In::vn()>`, :func:`3D<flamegpu::MessageArray3D::In::vn()>`
+Wrapped Von Neumann Neighbourhood ``FLAMEGPU->message_in.vn_wrap(<arguments>)``   ``message_in.vn_wrap(<arguments>)``             :func:`2D<flamegpu::MessageArray2D::In::vn_wrap()>`, :func:`3D<flamegpu::MessageArray3D::In::vn_wrap()>`
+================================= =============================================== =============================================== ==================================
 
-The *arguments* for each of these methods are identical. They simply require the search origin to be specified, and optionally a radius (by default a radius of 1 is used). In all cases, the radius must be a positive integer. Hence taking the form ``(x_pos, y_pos, z_pos, radius=1)`` in 3D, 2D and 1D lack the ``z_pos`` and ``y_pos`` arguments. 
+The ``arguments`` for each of these methods are identical. They simply require the search origin to be specified, and optionally a radius (by default a radius of 1 is used). In all cases, the radius must be a positive integer. Hence taking the form ``(x_pos, y_pos, z_pos, radius=1)`` in 3D, 2D and 1D lack the ``z_pos`` and ``y_pos`` arguments. 
 
 All array message iterators return messages over the exclusive neighbourhood of the selected type, hence the message at the search origin is never returned.
 
@@ -286,13 +417,13 @@ All array message iterators return messages over the exclusive neighbourhood of 
   * The Von Neumann iterator is generalised to support any radius. For this reason, if requiring radius 1, performance may be improved by accessing the 4 messages explicitly rather than using the iterator.
 
 
-Below are some examples using each of the iterators:
+Example of a Moore neighbourhood iterator:
 
 .. tabs::
 
-    .. code-tab:: cuda Moore
+    .. code-tab:: cuda Agent C++
 
-      // Define an agent function, "inputdata" which has accepts an input message using the "MessageSpatial3D" communication strategy and inputs no messages
+      // Define an agent function, "inputdata" which accepts an input message using the "MessageArray3D" communication strategy and outputs no messages
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageArray3D, flamegpu::MessageNone) {
           // Get this agent's x, y, z variables
           const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
@@ -306,10 +437,31 @@ Below are some examples using each of the iterators:
           }
           ...
       }
-      
-    .. code-tab:: cuda Wrapped Moore
 
-      // Define an agent function, "inputdata" which has accepts an input message using the "MessageSpatial2D" communication strategy and inputs no messages
+    .. code-tab:: py Agent Python
+
+      # Define an agent function, "inputdata" which accepts an input message using the "MessageArray3D" communication strategy and outputs no messages
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageArray3D, message_out: pyflamegpu.MessageNone):
+          # Get this agent's x, y, z variables
+          x = pyflamegpu.getVariableFloat("x")
+          y = pyflamegpu.getVariableFloat("y")
+          z = pyflamegpu.getVariableFloat("z")
+          # For each message in the exclusive Moore neighbourhood of radius 1
+          for message in pyflamegpu.message_in(x, y, z):        
+              # Process the message's variables
+              # var = message.getVariableInt(...)
+              ...
+          ...
+
+
+Example of wrapped Moore neighbourhood iterator:
+
+.. tabs::
+      
+    .. code-tab:: cuda Agent C++
+
+      // Define an agent function, "inputdata" which accepts an input message using the "MessageArray2D" communication strategy and outputs no messages
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageArray2D, flamegpu::MessageNone) {
         // Get this agent's x, y variables
         const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
@@ -322,16 +474,36 @@ Below are some examples using each of the iterators:
         }
         ...
       }
-      
-    .. code-tab:: cuda Von Neumann
 
-      // Define an agent function, "inputdata" which has accepts an input message using the "MessageSpatial3D" communication strategy and inputs no messages
+
+    .. code-tab:: py Agent Python
+
+      // Define an agent function, "inputdata" which has accepts an input message using the "MessageArray2D" communication strategy and outputs no messages
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageArray2D, message_out: pyflamegpu.MessageNone):
+          # Get this agent's x, y, z variables
+          x = pyflamegpu.getVariableFloat("x")
+          y = pyflamegpu.getVariableFloat("y")
+          # For each message in the exclusive wrapped Moore neighbourhood of radius 2
+          for message in pyflamegpu.message_in.wrap(x, y, 2):        
+              # Process the message's variables
+              # var = message.getVariableInt(...)
+              ...
+          ...
+      
+Example of a Von Neumann neighbourhood iterator:
+
+.. tabs::
+      
+    .. code-tab:: cuda Agent C++
+
+      // Define an agent function, "inputdata" which has accepts an input message using the "MessageArray3D" communication strategy and outputs no messages
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageArray3D, flamegpu::MessageNone) {
         // Get this agent's x, y, z variables
         const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
         const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
         const unsigned int z = FLAMEGPU->getVariable<unsigned int>("z");
-         // For each message in the exclusive Von Neumann neighbourhood of radius 2
+        // For each message in the exclusive Von Neumann neighbourhood of radius 2
         for (const auto& message : FLAMEGPU->message_in.vn(x, y, z, 2)) {        
           // Process the message's variables          
           // const T var = message.getVariable<T>(...);
@@ -339,10 +511,32 @@ Below are some examples using each of the iterators:
         }
         ...
       }
-      
-    .. code-tab:: cuda Wrapped Von Neumann
 
-      // Define an agent function, "inputdata" which has accepts an input message using the "MessageSpatial2D" communication strategy and inputs no messages
+
+    .. code-tab:: py Agent Python
+
+      // Define an agent function, "inputdata" which has accepts an input message using the "MessageArray3D" communication strategy and outputs no messages
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageArray3D, message_out: pyflamegpu.MessageNone):
+          # Get this agent's x, y, z variables
+          x = pyflamegpu.getVariableFloat("x")
+          y = pyflamegpu.getVariableFloat("y")
+          z = pyflamegpu.getVariableFloat("z")
+          # For each message in the exclusive Von Neumann neighbourhood of radius 2
+          for message in pyflamegpu.message_in.vn(x, y, z, 2):        
+              # Process the message's variables
+              # var = message.getVariableInt(...)
+              ...
+          ...
+      
+
+Example of a wrapped Von Neumann neighbourhood iterator:
+
+.. tabs::
+      
+    .. code-tab:: cuda Agent C++
+
+      // Define an agent function, "inputdata" which has accepts an input message using the "MessageArray2D" communication strategy and outputs no messages
       FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageArray2D, flamegpu::MessageNone) {
         // Get this agent's x, y, z variables
         const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
@@ -355,7 +549,22 @@ Below are some examples using each of the iterators:
         }
         ...
       }
-      
+
+    .. code-tab:: py Agent Python
+
+      // Define an agent function, "inputdata" which has accepts an input message using the "MessageArray2D" communication strategy and outputs no messages
+      @pyflamegpu.agent_function
+      def inputdata(message_in: pyflamegpu.MessageArray2D, message_out: pyflamegpu.MessageNone):
+          # Get this agent's x, y, z variables
+          x = pyflamegpu.getVariableFloat("x")
+          y = pyflamegpu.getVariableFloat("y")
+          # For each message in the exclusive wrapped Von Neumann neighbourhood of radius 1
+          for message in pyflamegpu.message_in.vn_wrap(x, y):        
+              # Process the message's variables
+              # var = message.getVariableInt(...)
+              ...
+          ...
+     
 
 Related Links
 -------------

--- a/src/guide/agent-functions/conditional-behaviours.rst
+++ b/src/guide/agent-functions/conditional-behaviours.rst
@@ -7,7 +7,7 @@ Agent function conditions are executed by all agents in the input state before t
 or ``false``. Agents which return ``true`` pass the condition and continue to execute the agent function and transition
 to the end state, agents which return ``false`` fail the condition, do not execute the agent function and remain in the input state.
 
-Agent function conditions are specified using the :c:macro:`FLAMEGPU_AGENT_FUNCTION_CONDITION`, this differs from the normal agent function macro as only the function condition name must be specified.
+Agent function conditions are specified using the :c:macro:`FLAMEGPU_AGENT_FUNCTION_CONDITION` in C++, this differs from the normal agent function macro as only the function condition name must be specified. Agent function conditions are not supported in the Python format (used for agent functions) but can be specified as C++ strings within the Python interface.
 
 Within agent function conditions a reduced read-only Device API, :class:`ReadOnlyDeviceAPI<flamegpu::ReadOnlyDeviceAPI>`, is available. This only permits reading agent variables, reading environment variables and random number generation.
 
@@ -15,7 +15,7 @@ Example definition of an agent function condition:
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
 
       // This agent function condition only allows agents who's 'x' variable equals '1' to progress
       FLAMEGPU_AGENT_FUNCTION_CONDITION(x_is_1) {

--- a/src/guide/agent-functions/defining-agent-functions.rst
+++ b/src/guide/agent-functions/defining-agent-functions.rst
@@ -3,14 +3,19 @@
 Defining Agent Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Agent Functions can be specified as CUDA functions, built at compile time when using the C++ API, or they can be specified as Run-Time Compiled (RTC) function strings when using the both the C++ and Python APIs.
+Agent Functions can be specified as C++ functions, built at compile time when using the C++ API, or they can be specified as Run-Time Compiled (RTC) function strings when using the both the C++ and Python APIs. Although agent functions are technically CUDA device code the FLAME GPU API abstracts this and no CUDA syntax is required to script behaviour. The same limitations apply to agent functions as to CUDA C++, the most significant restriction being standard libraries are not supported unless specified otherwise (see `CUDA documentation <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#restrictions>`_ for more details). C++ agent functions are distinguished within the examples in this guide by using the name *Agent C++* so that it is clear that this is a subset of supported C++.
 
-An agent function is defined using the :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro. 
+An experimental feature for Python allows the specification of native agent functions in Python. The Python can then be transpiled, a process of translating the Python syntax to equivalent C++, at runtime. A limited subset of Python is supported which is restricted to Python features that can be *easily* transpiled to a C++ equivalent at runtime for compilation. For example Python functionality like generator expressions, arrays, dictionaries, etc, which do not have an obvious C++ equivalent are not permitted and will raise an exception. The subset of supported Python is referred to as *Agent Python* within this guide.
+
+C++ Compile Time Agent Functions
+--------------------------------
+
+A C++ agent function is can be defined for compilation using the :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro. 
 This takes three arguments: a unique name identifying the function, an input message communication strategy, and an output message communication strategy.
 We will discuss messages in more detail later, so for now don't worry about the second and third parameters. :class:`flamegpu::MessageNone` is specified when not requiring message input or output, so this is used.
 Similarly, agent functions should return :enumerator:`flamegpu::ALIVE<flamegpu::AGENT_STATUS::ALIVE>` by default, agent death is explained in a :ref:`later section<agent birth death>` of this chapter.
 
-For Non-RTC functions, when using the C++ API, the :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro can be used to declare and define the agent function, which can then be associated with the :class:`AgentDescription<flamegpu::AgentDescription>` object using the :func:`newFunction()<flamegpu::AgentDescription::newFunction>` method.
+For compile time (i.e. non-RTC functions), when using the C++ API, the :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro can be used to declare and define the agent function, which can then be associated with the :class:`AgentDescription<flamegpu::AgentDescription>` object using the :func:`newFunction()<flamegpu::AgentDescription::newFunction>` method.
 
 
 .. tabs::
@@ -32,7 +37,12 @@ For Non-RTC functions, when using the C++ API, the :c:macro:`FLAMEGPU_AGENT_FUNC
         // ...
     }
 
-When using the Run-Time Compiled (RTC) functions, optionally in the C++ API or required by the Python API, the function must be defined in a string and associated with the :class:`AgentDescription<flamegpu::AgentDescription>` using the :func:`newRTCFunction()<flamegpu::AgentDescription::newRTCFunction>` method.
+C++ and Python Runtime Compiled Agent Functions
+-----------------------------------------------
+
+Run-time compiled C++ style agent functions follow the same syntax as for C++ compile time agent functions with the exception that the function must be defined in a string and associated with the :class:`AgentDescription<flamegpu::AgentDescription>` using the :func:`newRTCFunction()<flamegpu::AgentDescription::newRTCFunction>` method.
+
+Runtime C++ style compiled functions can be used with both the the C++ and Python APIs.
 
 .. cpp syntax highlighting due to issues with the cuda highlighter and raw strings.
 .. tabs::
@@ -74,38 +84,163 @@ When using the Run-Time Compiled (RTC) functions, optionally in the C++ API or r
     
 .. note::
 
-    If you wish to store RTC agent functions in separate files :func:`newRTCFunction()<flamegpu::AgentDescription::newRTCFunction>` can be replaced with :func:`newRTCFunctionFile()<flamegpu::AgentDescription::newRTCFunctionFile>`, instead passing the path to the agent function's source file (relative to the working directory at runtime). This will allow them to be developed in a text editor with C++/CUDA syntax highlighting.
+    If you wish to store RTC agent functions in separate files :func:`newRTCFunction()<flamegpu::AgentDescription::newRTCFunction>` can be replaced with :func:`newRTCFunctionFile()<flamegpu::AgentDescription::newRTCFunctionFile>`, instead passing the path to the agent function's source file (relative to the working directory at runtime). This will allow them to be developed in a text editor with C++ syntax highlighting.
+
+.. _Python Agent Functions:
+
+FLAME GPU Python Agent Functions
+--------------------------------
+
+Python agent functions are required to have the ``@pyflamegpu.agent_function`` decorator and must specify two arguments, the ``message_in`` and ``message_out`` variables (although the names can be changed), both of which must use a type annotation of a :ref:`supported message type<Communication Strategies>` prefixed with the Python FLAME GPU module name ``pyflamegpu.``.
+
+.. tabs::
+
+  .. code-tab:: py Agent Python
+
+    #Define an agent function called agent_fn1
+    @pyflamegpu.agent_function
+    def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageNone):
+        # Behaviour goes here
+        pass
+
+    ...
+    # Transpile the Python agent function to equivalent C++ (and transpile errors with raise an exception at this stage)
+    agent_fn1_translated = pyflamegpu.codegen.translate(agent_fn1) 
+
+    # Attach Python function called agent_fn1 to an agent represented by the AgentDescription agent (the function will be compiled at runtime as C++)
+    agent.newRTCFunction("agent_fn1", agent_fn1_translated)
+    ...
+    
+Supported Function Calls
+""""""""""""""""""""""""
+
+The Python transpiler supports function calls that have a C++ equivalent in the will check function calls in the API. The API singleton is available as ``pyflamegpu`` which is equivalent to the ``FLAMEGPU`` object in C++. If non existent functions are called on API objects then this will raise an error during translation. Calling of correctly specified device functions is also supported as well as calls to a small number of python built in functions. E.g. ``abs()``, ``int()``, and ``float()``. Any calls to math library functions are directly translated to C++ equivalents. E.g. ``Math.sinf()`` will result in a call to ``sinf()`` in C++. The majority of python math functions directly translate to their C++ counterparts. 
+
+Supported Math Constants
+""""""""""""""""""""""""
+
+The following mathematics constants are supported;
+
+============= =================================
+Python        Description
+============= =================================
+``math.pi``   Translated of ``M_PI`` in C++
+``math.e``    Translated of ``M_E`` in C++
+``math.inf``  Translated of ``INFINITY`` in C++
+``math.nan``  Translated of ``NAN`` in C++
+============= =================================
+
+.. _Python Types:
+
+Typed API Functions
+"""""""""""""""""""
+
+Calls to many FLAME GPU API functions are typed using template arguments in C++. In the Python equivalents the type is specified by calling a type instantiated version of the function using a suffix. The following type suffix are supported;
+
+============= ===============================================
+Type Suffix   C++ Equivalent type
+============= ===============================================
+``Char``      Would be ``char`` type template argument 
+``Float``     Would be ``float`` type template argument 
+``Double``    Would be ``double`` type template argument 
+``Int``       Would be ``int`` type template argument (the same as Int32)
+``UInt``      Would be ``unsigned int`` type template argument (the same as UInt32)
+``Int8``      Would be ``int_8`` type template argument 
+``UInt8``     Would be ``uint_8`` type template argument 
+``Int16``     Would be ``int_16`` type template argument 
+``UInt16``    Would be ``uint_16`` type template argument 
+``Int32``     Would be ``int_32`` type template argument 
+``UInt32``    Would be ``uint_32`` type template argument 
+``Int64``     Would be ``int_64`` type template argument 
+``UInt64``    Would be ``uint_64`` type template argument 
+============= ===============================================
+
+In each case the type is appended to the end of the API function. E.g. ``getVariableInt("name")`` in Python would be ``getVariable<"int">("name")`` in C++, and ``getVariableFloat("name")`` would be  ``getVariable<"float">("name")``  in C++
+
 
 FLAME GPU Device Functions
 --------------------------
 
-If you wish to define regular functions which can be called from agent functions, you can use the :c:macro:`FLAMEGPU_DEVICE_FUNCTION` macro:
+If you wish to define regular functions which can be called from agent functions, you can use the :c:macro:`FLAMEGPU_DEVICE_FUNCTION` macro (in C++), or the ``@pyflamegpu.device_function`` decorator for Python. Python device functions require type annotations for arguments and the function return type using supported types.
+
+====================== =================================================================================
+Type                   Description
+====================== =================================================================================
+``int``                Python built in ``int`` type which will translate transpile to a C++ ``int``
+``float``              Python built in ``float`` type which will translate transpile to a C++ ``float`` 
+``numpy.byte``         A numpy ``byte`` type which will transpile to a C++ ``char``
+``numpy.ubyte``        A numpy ``ubyte`` type which will transpile to a C++ ``unsigned char``
+``numpy.short``        A numpy ``short`` type which will transpile to a C++ ``short``
+``numpy.ushort``       A numpy ``ushort`` type which will transpile to a C++ ``unsigned short``
+``numpy.intc``         A numpy ``intc`` type which will transpile to a C++ ``int``
+``numpy.uintc``        A numpy ``uintc`` type which will transpile to a C++ ``unsigned int``
+``numpy.uint``         A numpy ``uint`` type which will transpile to a C++ ``unsigned int``
+``numpy.longlong``     A numpy ``longlong`` type which will transpile to a C++ ``long long``
+``numpy.ulonglong``    A numpy ``ulonglong`` type which will transpile to a C++ ``unsigned long long``
+``numpy.half``         A numpy ``half`` type which will transpile to a C++ ``half``
+``numpy.single``       A numpy ``single`` type which will transpile to a C++ ``float``
+``numpy.double``       A numpy ``double`` type which will transpile to a C++ ``double``
+``numpy.longdouble``   A numpy ``longdouble`` type which will transpile to a C++ ``long double`` (not currently supported in device code but left for completeness)
+``numpy.bool_``        A numpy ``bool_`` type which will transpile to a C++ ``bool``
+``numpy.bool8``        A numpy ``bool8`` type which will transpile to a C++ ``bool``
+``numpy.int_``         A numpy ``int_`` type which will transpile to a C++ ``long``
+``numpy.int8``         A numpy ``int8`` type which will transpile to a C++ ``int8_t``
+``numpy.int16``        A numpy ``int16`` type which will transpile to a C++ ``int16_t``
+``numpy.int32``        A numpy ``int32`` type which will transpile to a C++ ``int32_t``
+``numpy.int64``        A numpy ``int64`` type which will transpile to a C++ ``int64_t``
+``numpy.intp``         A numpy ``intp`` type which will transpile to a C++ ``intptr_t``
+``numpy.uint_``        A numpy ``uint_`` type which will transpile to a C++ ``long``
+``numpy.uint8``        A numpy ``uint8`` type which will transpile to a C++ ``uint8_t``
+``numpy.uint16``       A numpy ``uint16`` type which will transpile to a C++ ``uint16_t``
+``numpy.uint32``       A numpy ``uint32`` type which will transpile to a C++ ``uint32_t``
+``numpy.uint64``       A numpy ``uint64`` type which will transpile to a C++ ``uint64_t``
+``numpy.uintp``        A numpy ``uintp`` type which will transpile to a C++ ``uintptr_t``
+``numpy.float_``       A numpy ``float_`` type which will transpile to a C++ ``float``
+``numpy.float16``      A numpy ``float16`` type which will transpile to a C++ ``half``
+``numpy.float32``      A numpy ``float32`` type which will transpile to a C++ ``float``
+``numpy.float64``      A numpy ``float64`` type which will transpile to a C++ ``double``
+====================== =================================================================================
+
+Any runtime compiled agent functions must include the definition of any device functions in the agent function string. These can not be shared between agent functions (as each has a unique string definition).
+
+Python agent device functions must be contained in the source file of any agent functions which call them. All device functions are automatically discovered and included during the transpilation process. 
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
 
     // Define a function for adding two integers which can be called inside agent functions.
     FLAMEGPU_DEVICE_FUNCTION int add(int a, int b) {
         return a + b;
     }
+
+  .. code-tab:: py Agent Python
+
+    # Define a function for adding two integers which can be called inside agent functions.
+    @pyflamegpu.device_function
+    def add(a: int, b: int) -> int :
+      return a + b
+
     
-
-
 FLAME GPU Host Device Functions
 -------------------------------
 
-If you wish to define regular functions which can be called from within agent and host functions, you can use the :c:macro:`FLAMEGPU_HOST_DEVICE_FUNCTION` macro:
+If you wish to define regular functions which can be called from within agent and host functions, you can use the :c:macro:`FLAMEGPU_HOST_DEVICE_FUNCTION` macro.
+
+Host Device functions are not currently supported by the Python agent function format.
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
 
     // Define a function for subtracting two integers which can be called inside agent functions, or in host code
     FLAMEGPU_HOST_DEVICE_FUNCTION int subtract(int a, int b) {
         return a - b;
     }
-    
+
+
+
+
     
 Related Links
 -------------

--- a/src/guide/agent-functions/index.rst
+++ b/src/guide/agent-functions/index.rst
@@ -10,6 +10,7 @@ Each agent has one or more agent functions, which allow agents to interact with 
 Each agent function in FLAME GPU 2 is associated with a particular agent type and is represented by an :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` object. This object describes the name of the function, the agent state in which it should be active, and any state transitions it should apply to the agent. 
 
 The implementation code for the behaviour (the actual agent function) can be specified in three alternative ways;
+
 * As a globally scoped (CUDA) C++ function, labelled with the :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro
 * As a C++ function labelled with teh :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro but written as a string (supported in either a C++ or Python 3)
 * As a global scoped Python 3 function annotated as `@pyflamegpu.agent_function` which will be transpiled to equivalent C++ and which is compiled at runtime

--- a/src/guide/agent-functions/index.rst
+++ b/src/guide/agent-functions/index.rst
@@ -13,7 +13,7 @@ The implementation code for the behaviour (the actual agent function) can be spe
 
 * As a globally scoped (CUDA) C++ function, labelled with the :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro
 * As a C++ function labelled with teh :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro but written as a string (supported in either a C++ or Python 3)
-* As a global scoped Python 3 function annotated as `@pyflamegpu.agent_function` which will be transpiled to equivalent C++ and which is compiled at runtime
+* As a global scoped Python 3 function annotated as ``@pyflamegpu.agent_function`` which will be transpiled to equivalent C++ and which is compiled at runtime
 
 This chapter has been broken up into several sections:
 

--- a/src/guide/agent-functions/index.rst
+++ b/src/guide/agent-functions/index.rst
@@ -7,8 +7,12 @@ As FLAME GPU is an agent-based modelling framework, agent functions are central 
 
 Each agent has one or more agent functions, which allow agents to interact with the environment and other agents. Additionally, agent functions can be conditionally executed based on agent states and properties.
 
-Each agent function in FLAME GPU 2 is associated with a particular agent type and is represented by an :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` object. This object describes the name of the function, the agent state in which it should be active, and any state transitions it should apply to the agent. The implementation code for the behaviour is written separately and is identified by using the
-:c:macro:`FLAMEGPU_AGENT_FUNCTION` macro to label the code. Alternatively, the implementations can be written in strings and loaded at runtime. The latter method is the only method supported by FLAME GPU 2's Python API.
+Each agent function in FLAME GPU 2 is associated with a particular agent type and is represented by an :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` object. This object describes the name of the function, the agent state in which it should be active, and any state transitions it should apply to the agent. 
+
+The implementation code for the behaviour (the actual agent function) can be specified in three alternative ways;
+* As a globally scoped (CUDA) C++ function, labelled with the :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro
+* As a C++ function labelled with teh :c:macro:`FLAMEGPU_AGENT_FUNCTION` macro but written as a string (supported in either a C++ or Python 3)
+* As a global scoped Python 3 function annotated as `@pyflamegpu.agent_function` which will be transpiled to equivalent C++ and which is compiled at runtime
 
 This chapter has been broken up into several sections:
 

--- a/src/guide/agent-functions/interacting-with-environment.rst
+++ b/src/guide/agent-functions/interacting-with-environment.rst
@@ -143,7 +143,7 @@ Example usage is shown below:
     }
     
 .. warning::
-  Be careful when using :class:`DeviceMacroProperty<flamegpu::DeviceMacroProperty>`. When you retrieve an element e.g. ``location[0][0][0]`` (from the example above), it is of type :class:`DeviceMacroProperty<flamegpu::DeviceMacroProperty>` not ``unsigned int``. Therefore you cannot pass it directly to functions which take generic arguments such as ``printf()``, as it will be interpreted incorrectly. You must either store it in a variable of the correct type which you instead pass, or explicitly cast it to the correct type when passing it e.g. ``(unsigned int)location[0][0][0]`` or ``static_cast<unsigned int>(location[0][0][0])`` (or ``int(location[0][0][0])`` in Python).
+  Be careful when using :class:`DeviceMacroProperty<flamegpu::DeviceMacroProperty>`. When you retrieve an element e.g. ``location[0][0][0]`` (from the example above), it is of type :class:`DeviceMacroProperty<flamegpu::DeviceMacroProperty>` not ``unsigned int``. Therefore you cannot pass it directly to functions which take generic arguments such as ``printf()``, as it will be interpreted incorrectly. You must either store it in a variable of the correct type which you instead pass, or explicitly cast it to the correct type when passing it e.g. ``(unsigned int)location[0][0][0]`` or ``static_cast<unsigned int>(location[0][0][0])`` (or ``numpy.uint(location[0][0][0])`` in Python).
     
     
 Related Links

--- a/src/guide/agent-functions/modifying-agent-variables.rst
+++ b/src/guide/agent-functions/modifying-agent-variables.rst
@@ -9,10 +9,11 @@ These variables are accessed from higher latency device memory, so for the best 
 that you avoid multiple reads or writes to the same variable in any agent functions and do as much as possible
 with the local copy.
 
+Agent Python supports agent variables using :ref:`typed versions of functions<Python Types>`.
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
 
     FLAMEGPU_AGENT_FUNCTION(ExampleFn, flamegpu::MessageNone, flamegpu::MessageNone) {
         // Fetch the agent's ID
@@ -31,12 +32,33 @@ with the local copy.
         ...
     }
 
+  .. code-tab:: py Agent Python
+
+    @pyflamegpu.agent_function
+    def ExampleFn(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageNone):
+        # Fetch the agent's ID
+        ID = pyflamegpu.getID()
+        
+        # Get the value of agent variable 'x' and store it in local variable 'x'
+        x = pyflamegpu.getVariableInt("x")
+
+        # Modify the variable in some way
+        x += 2;
+
+        # Store the updated value in the agent's 'x' variable
+        pyflamegpu.setVariableInt("x", x)
+
+        # Other behaviour code
+        ...
+
 Agent variables can also be arrays, accessing these requires extra arguments. It is not possible to retrieve or set a full array
 in a single function call, during agent functions elements can only be accessed individually.
 
+Within Python agent functions array lengths can be be specified by appending ``ArrayX`` to the name of the function call, where ``X`` is the array length.
+
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
 
     FLAMEGPU_AGENT_FUNCTION(ExampleFn, flamegpu::MessageNone, flamegpu::MessageNone) {
         // Return agent variable 'location[1]' and store it in local variable 'y'
@@ -52,6 +74,23 @@ in a single function call, during agent functions elements can only be accessed 
         // Other behaviour code
         ...
     }
+
+  .. code-tab:: py Agent Python
+
+    @pyflamegpu.agent_function
+    def ExampleFn(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageNone):
+        # Return agent variable 'location[1]' and store it in local variable 'y'
+        # The length of the array must be appended to the name of the type instantiated getVariable function, in this example the array has a length of 3
+        y = pyflamegpu.getVariableIntArray3("location", 1);
+
+        # Update the local copy
+        y+=1;
+
+        # Store the updated local copy in the agent's 'location[1]' variable
+        FLAMEGPU->setVariableIntArray3("location", 1, y);
+
+        # Other behaviour code
+        ...
     
 Reading an Agent's ID
 ---------------------
@@ -60,7 +99,7 @@ The built-in agent ID variable, which is unique to each agent instance, can also
     
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
 
     FLAMEGPU_AGENT_FUNCTION(ExampleFn, flamegpu::MessageNone, flamegpu::MessageNone) {
         // Fetch the agent's ID, id_t is an unsigned int variable
@@ -70,6 +109,15 @@ The built-in agent ID variable, which is unique to each agent instance, can also
         ...
     }
 
+  .. code-tab:: py Agent Python
+
+    @pyflamegpu.agent_function
+    def ExampleFn(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageNone):
+        # Fetch the agent's ID
+        ID = pyflamegpu.getID()
+
+    # Other behaviour code
+    ...
     
 .. note ::
     To achieve the high performance of FLAME GPU 2, agent behaviours must be implemented as agent functions which execute on the GPU, rather than in host functions which run on the CPU. 

--- a/src/guide/agent-functions/random-numbers.rst
+++ b/src/guide/agent-functions/random-numbers.rst
@@ -3,7 +3,7 @@
 Random Numbers
 ^^^^^^^^^^^^^^
 
-Usage of the :class:`DeviceAPI<flamegpu::DeviceAPI>` random methods matches that of the :class:`HostAPI<flamegpu::HostAPI>`. The :class:`AgentRandom<flamegpu::AgentRandom>` instance can be accessed in agent functions via ``FLAMEGPU->random``.
+Usage of the :class:`DeviceAPI<flamegpu::DeviceAPI>` random methods matches that of the :class:`HostAPI<flamegpu::HostAPI>`. The :class:`AgentRandom<flamegpu::AgentRandom>` instance can be accessed in agent functions via ``FLAMEGPU->random`` (``pyflamegpu.random`` in Python).
 
 These random numbers are seeded according to the simulation's random seed specified at runtime. This can be read and updated via host functions.
 
@@ -16,11 +16,11 @@ Name                Arguments            Description
 ``logNormal``       ``mean``, ``stddev`` Returns a log-normally distributed floating point number with the specified mean and standard deviation
 =================== ==================== =======================================================================================================
 
-When calling any of these methods the type must be specified. Most methods only support floating point types (e.g. ``float``, ``double``), with the exception of the parametrised ``uniform`` method which is restricted to integer types:
+When calling any of these methods in C++ the type must be specified. Most methods only support floating point types (e.g. ``float``, ``double``), with the exception of the parametrised ``uniform`` method which is restricted to integer types: Within Python the variable :ref:`type<Python Types>` must be appended to the name of the agent function.
 
 .. tabs::
 
-  .. code-tab:: cuda CUDA C++
+  .. code-tab:: cuda Agent C++
   
     FLAMEGPU_AGENT_FUNCTION(agent_fn1, flamegpu::MessageNone, flamegpu::MessageNone) {
         // Generate a uniform random float [0, 1)
@@ -30,6 +30,15 @@ When calling any of these methods the type must be specified. Most methods only 
         
         ...
     }
+
+  .. code-tab:: py Agent Python
+  
+    @pyflamegpu.agent_function
+    def OptionalOutput(agent_fn1: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageNone):
+        # Generate a uniform random float [0, 1)
+        uniform_float = pyflamegpu.random.uniformFloat()
+        # Generate a uniform random integer [1, 10]
+        uniform_int = pyflamegpu.random.uniformInt(1, 10);
 
 Related Links
 -------------

--- a/src/guide/defining-messages-communication/index.rst
+++ b/src/guide/defining-messages-communication/index.rst
@@ -5,6 +5,7 @@ Defining Messages (Communication)
 
 Communication between agents in FLAME GPU is handled through messages. Messages contain variables which are used to transmit information between agents. Agents may output a single message from an agent function, subsequent agent functions can then be configured to access messages of the same type according to the message's communication strategy.
 
+.. _Communication Strategies:
 
 Communication Strategies
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Adds device side examples for all current CUDA C++. Discussion required about naming of this. I personally don't like CUDA C++ as it implies a user might need to know CUDA. The abstraction is to specifically avoid this so it might be better to use "Agent Function/Device C++" and provide some context as to the fact that this is a subset of C++ supported by CUDA in the docs. Pure Python has also been used to describe the Python device side code. This could potentially also be changed.

Main repo PR: https://github.com/FLAMEGPU/FLAMEGPU2/pull/882