### PR TITLE
Update 3rd party github actions to fix GHA node deprecation warnings.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,13 @@ jobs:
       werror: ${{ matrix.werror }}
     steps:
     - name: Checkout FLAMEGPU2/FLAMEGPU2-docs
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: FLAMEGPU2-docs
 
     - name: Checkout FLAMEGPU2/FLAMEGPU2
       if: env.build_api_docs == 'ON'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: FLAMEGPU/FLAMEGPU2
         path: FLAMEGPU2
@@ -56,7 +56,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.python != '' }} 
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python }}
 
@@ -90,7 +90,7 @@ jobs:
 
     - name: Upload Artifact on PR
       if: ${{ github.event_name == 'pull_request' && matrix.werror == 'OFF'}}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: userguide-py${{ env.python }}${{ fromJSON('{true:"-NOAPI",false:""}')[matrix.werror == 'OFF' && matrix.build_api_docs == 'OFF'] }}
         path: FLAMEGPU2-docs/build/html.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,14 +16,14 @@ jobs:
     steps:
     # Chekout this repository into specified path
     - name: Checkout FLAMEGPU2/FLAMEGPU2-docs
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: FLAMEGPU2-docs
 
     # If API docs are being built, check them out into a subfolder.
     - name: Checkout FLAMEGPU2/FLAMEGPU2
       if: env.build_api_docs == 'ON'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: FLAMEGPU/FLAMEGPU2
         path: FLAMEGPU2
@@ -39,7 +39,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.python != '' }} 
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python }}
 


### PR DESCRIPTION
Should close #115 (hopefully). 

It won't fix the warnings on the github pages deployment jobs which we have no control over. 