### PR TITLE
Updated verbosity docs

### DIFF
--- a/src/guide/running-a-simulation/configuring-execution.rst
+++ b/src/guide/running-a-simulation/configuring-execution.rst
@@ -15,7 +15,8 @@ Config Variable         Long Argument              Short Argument     Descriptio
 ``truncate_log_files``  n/a                        n/a                If true, log files will overwrite any pre-existing file with the same path/name. Default value true.
 ``random_seed``         ``--random <int>``         ``-r <int>``       Random seed. Default value is sample from the clock (e.g. it will change each run).
 ``steps``               ``--steps <int>``          ``-s <int>``       Number of simulation steps to execute. 0 will run indefinitely, or until an exit function causes the simulation to end. Default value 1.    
-``verbose``             ``--verbose``              ``-v``             Enable verbose simulation output to console. Default value false.
+``quiet``               ``--quiet``                ``-q``             Don't print ensemble progress to console.
+``verbose``             ``--verbose``              ``-v``             Print config, progress and timing (-t) information to console.
 ``timing``              ``--timing``               ``-t``             Output simulation timing detail to console. Default value false.
 ``console_mode``        ``--console``              ``-c``             Visualisation builds only, disable the visualisation. Default value false.
 ``device_id``           ``--device <device id>``   ``-d <device id>`` The CUDA device id of the GPU to use. Default value 0 (Note this is found within :class:`CUDASimulation::Config<flamegpu::CUDASimulation::Config>`)

--- a/src/guide/running-a-simulation/initial-state.rst
+++ b/src/guide/running-a-simulation/initial-state.rst
@@ -203,7 +203,7 @@ The below code block displays example files output from FLAME GPU 2 in both XML 
                 <truncate_log_files>true</truncate_log_files>
                 <random_seed>1643029170</random_seed>
                 <steps>1</steps>
-                <verbose>false</verbose>
+                <verbosity>1</verbosity>
                 <timing>false</timing>
                 <console_mode>false</console_mode>
             </simulation>
@@ -254,7 +254,7 @@ The below code block displays example files output from FLAME GPU 2 in both XML 
           "truncate_log_files": true,
           "random_seed": 1643029117,
           "steps": 1,
-          "verbose": false,
+          "verbosity": 1,
           "timing": false,
           "console_mode": false
         },

--- a/src/guide/running-multiple-simulations/index.rst
+++ b/src/guide/running-multiple-simulations/index.rst
@@ -195,6 +195,7 @@ Long Argument                  Short Argument              Description
                                                            By default 4 concurrent simulations will run per GPU.
 ``--out`` <directory> <format> ``-o`` <directory> <format> Directory and format (JSON/XML) for ensemble logging.
 ``--quiet``                    ``-q``                      Don't print ensemble progress to console.
+``--verbose``                  ``-v``                      Print config, progress and timing (-t) information to console.
 ``--timing``                   ``-t``                      Output timing information to console at exit.
 ``--error``                    ``-e`` <error level>        The :enum:`ErrorLevel<flamegpu::CUDAEnsemble::EnsembleConfig::ErrorLevel>` to use: 0, 1, 2, "off", "slow" or "fast".
                                                            By default the :enum:`ErrorLevel<flamegpu::CUDAEnsemble::EnsembleConfig::ErrorLevel>` will be set to "slow" (1).


### PR DESCRIPTION
Clarified consistent use of verbose and quiet in Ensemble and Simulation. Also updated any examples using verbose/quiet. 