### PR TITLE
Remove references to __disown__()

### DIFF
--- a/src/guide/debugging-models/logging.rst
+++ b/src/guide/debugging-models/logging.rst
@@ -151,7 +151,7 @@ A step function must also be added, to both copy the macro property to the envir
             nb_cycle_counter.zero()
             
     // Attach the step function to the model
-    model.addStepFunctionCallback(reset_counters().__disown__())
+    model.addStepFunctionCallback(reset_counters())
 
 Now the agent function can be updated to increment the counters at each branch
 

--- a/src/guide/defining-execution-order/exit-conditions.rst
+++ b/src/guide/defining-execution-order/exit-conditions.rst
@@ -44,7 +44,7 @@ In particular, submodels which are introduced in the :ref:`following section<Def
     ...
     
     # Add 'my_exit_condition' to 'model'
-    model.addExitConditionCallback(my_exit_condition().__disown__())
+    model.addExitConditionCallback(my_exit_condition())
 
 If a model has multiple exit conditions, they will be executed in the order that they were added to the model. 
 When multiple exit conditions are defined, conditions are only executed if earlier exit condition functions return :enumerator:`CONTINUE<flamegpu::CONDITION_RESULT::CONTINUE>`.

--- a/src/guide/defining-execution-order/layers.rst
+++ b/src/guide/defining-execution-order/layers.rst
@@ -66,7 +66,7 @@ The below example demonstrates adding an agent and host function to separate lay
     layer.addAgentFunction(outputdata_desc)
     
     # Create a new layer for the host function 'validation'
-    model.newLayer().addHostFunctionCallback(validation().__disown__())
+    model.newLayer().addHostFunctionCallback(validation())
 
 
 Layer Specification Rules

--- a/src/guide/defining-execution-order/submodels.rst
+++ b/src/guide/defining-execution-order/submodels.rst
@@ -66,7 +66,7 @@ When calling :func:`bindAgent()<flamegpu::SubModelDescription::bindAgent>`, it i
       s_af1 = s_a.newRTCFunction("example_function", ExampleFn)
       sub_m.newLayer().addFunction(s_af1)
       # Give the model an exit condition, this is required for all submodels
-      sub_m.addExitConditionCallback(ExitCdn().__disown__());
+      sub_m.addExitConditionCallback(ExitCdn());
 
       # Define the parent model
       m = pyflamegpu.ModelDescription("model")

--- a/src/guide/host-functions/defining-host-functions.rst
+++ b/src/guide/host-functions/defining-host-functions.rst
@@ -50,6 +50,12 @@ In the Python API a host function is defined as a subclass of :class:`HostFuncti
       def run(self, FLAMEGPU):
         # Behaviour goes here
         return pyflamegpu.CONTINUE
+        
+        
+.. warning::
+
+    Although python Host functions and conditions are classes, the class should not utilise any additional stateful information (e.g. `self`). When executed via ensembles, Python host function instances are shared between concurrent simulation runs, which may lead to race conditions where stateful information is present.
+    
 
 Types of Host Function
 ----------------------
@@ -130,14 +136,9 @@ The below example shows how an init function would be added to a model:
     model = pyflamegpu.ModelDescription("Test Model")
     ... # Rest of model definition
     # Add the exit function init_fn to Test Model
-    model.addInitFunctionCallback(init_fn().__disown__())
+    model.addInitFunctionCallback(init_fn())
     ...
 
-.. warning::
-
-    The above Python example calls ``__disown__()`` on the instance of ``init_fn`` created inline. Python host functions are created and owned by Python, only a reference to them is passed to the C++ internals. Calling ``__disown__()`` ensures that the Python owned host function will not go out of scope and be deallocated during the program's lifetime. Failing to call ``__disown__()`` can lead to undefined behaviour.
-    
-    For updates on this see the `issue on GitHub <https://github.com/FLAMEGPU/FLAMEGPU2/issues/498>`
 
 Related Links
 -------------

--- a/src/tutorial/index.rst
+++ b/src/tutorial/index.rst
@@ -734,13 +734,9 @@ Similar to agent functions, the initialisation function must be attached to the 
 
     ...
     dependencyGraph.generateLayers(model)
-    model.addInitFunctionCallback(create_agents().__disown__())
+    model.addInitFunctionCallback(create_agents())
     ...
     
-    
-.. warning ::
-    
-    It is important that ``__disown__()`` is called when creating the instance of the Python init (host) function callbacks. Without this, Python may decide to deallocate the instance early, leading to undefined behaviour. We are not yet able to detect, or prevent this automatically within FLAME GPU.
 
 Configuring the Simulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -808,7 +804,7 @@ After the :class:`StepLoggingConfig<flamegpu::StepLoggingConfig>` is fully defin
 
   .. code-tab:: py Python
   
-    ... # following on from model.addInitFunctionCallback(create_agents().__disown__())
+    ... # following on from model.addInitFunctionCallback(create_agents())
     
     # Specify the desired StepLoggingConfig
     step_log_cfg = pyflamegpu.StepLoggingConfig(model)
@@ -1229,7 +1225,7 @@ If you have followed the complete tutorial, you should now have the following co
       model.addRoot(out_fn)
       model.generateLayers()
 
-      model.addInitFunctionCallback(create_agents().__disown__())
+      model.addInitFunctionCallback(create_agents())
 
       # Specify the desired StepLoggingConfig
       step_log_cfg = pyflamegpu.StepLoggingConfig(model)
@@ -1382,7 +1378,7 @@ If you have followed the complete tutorial, you should now have the following co
                 t.setVariableFloat("x", FLAMEGPU.random.uniformFloat() * ENV_WIDTH)
                 t.setVariableFloat("y", FLAMEGPU.random.uniformFloat() * ENV_WIDTH)
                 
-    model.addInitFunctionCallback(create_agents().__disown__())
+    model.addInitFunctionCallback(create_agents())
 
     # Specify the desired StepLoggingConfig
     step_log_cfg = pyflamegpu.StepLoggingConfig(model)


### PR DESCRIPTION
This should now be called automatically.
I think I have removed all usages of `__disown__()` from the docs, checked using `grep -rnw "src/" -e "disown"`.


Relates:
* Issue: https://github.com/FLAMEGPU/FLAMEGPU2/issues/498
* PR: https://github.com/FLAMEGPU/FLAMEGPU2/pull/975 