### PR TITLE
CMake option/cache prefix changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       working-directory: FLAMEGPU2-docs
       run: |
         source .venv/bin/activate
-        cmake . -B build -DWARNINGS_AS_ERRORS=${{ env.werror }}
+        cmake . -B build -DFLAMEGPU_DOCS_WARNINGS_AS_ERRORS=${{ env.werror }}
 
     - name: Build
       working-directory: FLAMEGPU2-docs/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,14 @@ set(SPHINX_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/src")
 # set(SPHINX_CAHCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_doctrees")
 
 # Option to promote compilation warnings to error, useful for strict CI
-option(WARNINGS_AS_ERRORS "Promote compilation warnings to errors" OFF)
+option(FLAMEGPU_DOCS_WARNINGS_AS_ERRORS "Promote build warnings to errors" OFF)
 
 # Find graphviz which is required for the user guide (sphinx graphviz plugin)
 find_package(Graphviz REQUIRED)
 
-find_package(FLAMEGPU2)
+find_package(FLAMEGPU)
 # Build Doxygen if we can
-if(FLAMEGPU2_FOUND)
+if(FLAMEGPU_FOUND)
     # Load FLAMEGPU2s Doxygen config, implicitly calls find_package(doxygen)
     include(${FLAMEGPU_ROOT}/cmake/dependencies/doxygen.cmake)
     mark_as_advanced(FORCE BUILD_API_DOCUMENTATION)
@@ -130,10 +130,10 @@ endforeach()
 
 # Set the warnings_is_errors value if enabeld.
 set(SPHINX_WARNING_IS_ERROR_FLAG "")
-if (WARNINGS_AS_ERRORS)
+if (FLAMEGPU_DOCS_WARNINGS_AS_ERRORS)
     set(SPHINX_WARNING_IS_ERROR_FLAG "-W")
 endif()
-if(FLAMEGPU2_FOUND AND DOXYGEN_FOUND AND ${BUILD_API_DOCUMENTATION})
+if(FLAMEGPU_FOUND AND DOXYGEN_FOUND AND FLAMEGPU_BUILD_API_DOCUMENTATION)
     # Set the var used when generating conf.py to enable breathe/exhale 
     set(USE_BREATHE_EXHALE "True")
     set(EXCLUDE_API_PATTERN "") # Do not exlude the api dir
@@ -159,7 +159,7 @@ if(FLAMEGPU2_FOUND AND DOXYGEN_FOUND AND ${BUILD_API_DOCUMENTATION})
     unset(API_TOC_PATH)
 
     # Create Doxygen target 'userguide_docs_xml'
-    create_doxygen_target("${FLAMEGPU_ROOT}" "${CMAKE_CURRENT_BINARY_DIR}" "src/${API_DOCS_XML_PATH}")
+    flamegpu_create_doxygen_target("${FLAMEGPU_ROOT}" "${CMAKE_CURRENT_BINARY_DIR}" "src/${API_DOCS_XML_PATH}")
     # Create Sphinx target
     add_custom_target(userguide ALL
         COMMAND ${SPHINX_EXECUTABLE} -b html

--- a/cmake/FindFLAMEGPU.cmake
+++ b/cmake/FindFLAMEGPU.cmake
@@ -15,6 +15,6 @@ find_path(FLAMEGPU_ROOT include/flamegpu/defines.h
 include(FindPackageHandleStandardArgs)
  
 #Handle standard arguments to find_package like REQUIRED and QUIET
-find_package_handle_standard_args(FLAMEGPU2
+find_package_handle_standard_args(FLAMEGPU
                                   "Failed to find FLAMEGPU root"
                                   FLAMEGPU_ROOT)

--- a/cmake/FindGraphviz.cmake
+++ b/cmake/FindGraphviz.cmake
@@ -10,3 +10,5 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Graphviz
                                   "Failed to find dot executable"
                                   GRAPHVIZ_DOT_EXECUTABLE)
+
+mark_as_advanced(GRAPHVIZ_DOT_EXECUTABLE)

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -9,3 +9,5 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Sphinx
                                   "Failed to find sphinx-build executable"
                                   SPHINX_EXECUTABLE)
+
+mark_as_advanced(SPHINX_EXECUTABLE)

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,15 @@ You can optionally specify the location of the FLAMEGPU2 source repository:
 ```bash
 mkdir -p build && cd build
 cmake .. -DFLAMEGPU_ROOT="<absolute path to FLAMEGPU2>"
+cmake --build .
+```
+
+Building the API documentation can be disabled, to improve build times via the `FLAMEGPU_BUILD_API_DOCUMENTATION` option set to `OFF`:
+
+```bash
+mkdir -p build && cd build
+cmake .. -DFLAMEGPU_BUILD_API_DOCUMENTATION=OFF
+cmake --build .
 ```
 
 If you lack a build system, executing `windows.bat` inside the directory `cmake` provides an alternative. However, this still requires executing CMake if api documentation is required.

--- a/src/guide/agent-functions/agent-birth-death.rst
+++ b/src/guide/agent-functions/agent-birth-death.rst
@@ -64,7 +64,7 @@ To have an agent die, simply return :enumerator:`flamegpu::DEAD<flamegpu::AGENT_
             return pyflamegpu.ALIVE
 
 
-If :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` (``pyflamegpu.DEAD`` in Python) is returned by an agent function whilst agent death is not enabled the agent will not die. If ``SEATBELTS`` error checking is enabled an exception will be raised.
+If :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` (``pyflamegpu.DEAD`` in Python) is returned by an agent function whilst agent death is not enabled the agent will not die. If ``FLAMEGPU_SEATBELTS`` error checking is enabled an exception will be raised.
 
 
 Agent Birth
@@ -159,14 +159,14 @@ Agent creation is always optional once enabled, a new agent will only be marked 
         # Other agent function code
         ...
 
-If :class:`FLAMEGPU->agent_out<flamegpu::DeviceAPI::AgentOut>` is used in an agent function which has not had agent output enabled, no agent will be created. If ``SEATBELTS`` error checking is enabled, an exception will be raised.
+If :class:`FLAMEGPU->agent_out<flamegpu::DeviceAPI::AgentOut>` is used in an agent function which has not had agent output enabled, no agent will be created. If ``FLAMEGPU_SEATBELTS`` error checking is enabled, an exception will be raised.
 
 Related Links
 -------------
 
 * User Guide Page: :ref:`Defining Agents<Defining Agents>`
 * User Guide Page: :ref:`Agent Operations<Host Agent Operations>` (Host Functions)
-* User Guide Page: :ref:`What is SEATBELTS?<SEATBELTS>`
+* User Guide Page: :ref:`What is FLAMEGPU_SEATBELTS?<FLAMEGPU_SEATBELTS>`
 * Full API documentation for :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>`
 * Full API documentation for :class:`AgentOut<flamegpu::DeviceAPI::AgentOut>`
 * Full API documentation for :class:`DeviceAPI<flamegpu::DeviceAPI>`

--- a/src/guide/agent-functions/agent-communication.rst
+++ b/src/guide/agent-functions/agent-communication.rst
@@ -112,7 +112,7 @@ When outputting bucket messages, the bucket index for the message must be set, u
           pyflamegpu.message_out.setKey(pyflamegpu.getVariableInt("bucket"))
           return pyflamegpu.ALIVE
       
-Messages assigned keys outside of the bounds have undefined behaviour. If using ``SEATBELTS`` error checking, an exception will be raised.
+Messages assigned keys outside of the bounds have undefined behaviour. If using ``FLAMEGPU_SEATBELTS`` error checking, an exception will be raised.
 
 Spatial Messaging
 =================
@@ -155,7 +155,7 @@ If you are using :class:`MessageSpatial2D<flamegpu::MessageSpatial2D>` or :class
 Array Messaging
 ===============
 
-If you are using :class:`MessageArray<flamegpu::MessageArray>`, :class:`MessageArray2D<flamegpu::MessageArray2D>` or :class:`MessageArray3D<flamegpu::MessageArray3D>` then you must specify the corresponding array index when outputting a message. It is important that only 1 agent writes a message to each index. If ``SEATBELTS`` error-checking is enabled then multiple outputs to the same index will raise an exception.
+If you are using :class:`MessageArray<flamegpu::MessageArray>`, :class:`MessageArray2D<flamegpu::MessageArray2D>` or :class:`MessageArray3D<flamegpu::MessageArray3D>` then you must specify the corresponding array index when outputting a message. It is important that only 1 agent writes a message to each index. If ``FLAMEGPU_SEATBELTS`` error-checking is enabled then multiple outputs to the same index will raise an exception.
 
 .. tabs::
 
@@ -259,7 +259,7 @@ Bucket Messaging
 
 If you are using the Bucket messaging strategy, you will also need to supply the bucket key to access the messages from the specific bucket.
 
-If an invalid bucket key is specified (based on the bounds provided when the messagelist was defined) no messages will be returned. If ``SEATBELTS`` error checking is enabled, an exception will be raised.
+If an invalid bucket key is specified (based on the bounds provided when the messagelist was defined) no messages will be returned. If ``FLAMEGPU_SEATBELTS`` error checking is enabled, an exception will be raised.
 
 .. tabs::
 
@@ -314,7 +314,7 @@ Spatial messaging will return all messages within the radius specified at the mo
 
 .. note::
   When spatial messages will be accessed via the wrapped iterator, all messages locations must be within the environment bounds defined for the message list. Accessing out of bounds messages with the wrapped iterator is undefined behaviour. 
-  If using ``SEATBELTS`` error checking an error may be raised whilst using the wrapped iterator if an out of bounds message is read.
+  If using ``FLAMEGPU_SEATBELTS`` error checking an error may be raised whilst using the wrapped iterator if an out of bounds message is read.
 
 .. tabs::
 
@@ -645,7 +645,7 @@ Related Links
 -------------
 
 * User Guide Page: :ref:`Defining Messages (Communication)<Defining Messages>`
-* User Guide Page: :ref:`What is SEATBELTS?<SEATBELTS>`
+* User Guide Page: :ref:`What is FLAMEGPU_SEATBELTS?<FLAMEGPU_SEATBELTS>`
 * Full API documentation for :class:`MessageBruteForce::In<flamegpu::MessageBruteForce::In>` & :class:`MessageBruteForce::Out<flamegpu::MessageBruteForce::Out>`
 * Full API documentation for :class:`MessageBucket::In<flamegpu::MessageBucket::In>` & :class:`MessageBucket::Out<flamegpu::MessageBucket::Out>`
 * Full API documentation for :class:`MessageSpatial2D::In<flamegpu::MessageSpatial2D::In>` & :class:`MessageSpatial2D::Out<flamegpu::MessageSpatial2D::Out>`

--- a/src/guide/agent-functions/interacting-with-environment.rst
+++ b/src/guide/agent-functions/interacting-with-environment.rst
@@ -74,7 +74,7 @@ Environmental macro properties can be read, via the returned :class:`DeviceMacro
         # Other behaviour code
         ...
     
-They can also be updated with a selection of functions, which execute atomically. These functions will update a single variable and return information related to it's old or new state. This can be useful, for simple actions such as conflict resolution and counting. However, if a basic read is subsequently required, a separate host or agent function in a following layer must be used (otherwise there would be a race condition). If running with ``SEATBELTS`` error checking enabled, an exception should be thrown where potential race conditions are detected.
+They can also be updated with a selection of functions, which execute atomically. These functions will update a single variable and return information related to it's old or new state. This can be useful, for simple actions such as conflict resolution and counting. However, if a basic read is subsequently required, a separate host or agent function in a following layer must be used (otherwise there would be a race condition). If running with ``FLAMEGPU_SEATBELTS`` error checking enabled, an exception should be thrown where potential race conditions are detected.
 
 Macro properties support the normal :func:`+<flamegpu::DeviceMacroProperty::operator+>`, :func:`-<flamegpu::DeviceMacroProperty::operator->`, :func:`+=<flamegpu::DeviceMacroProperty::operator+=>`, :func:`-=<flamegpu::DeviceMacroProperty::operator-=>`, :func:`++<flamegpu::DeviceMacroProperty::operator++>` (only C++ supports pre and post increment), :func:`--<flamegpu::DeviceMacroProperty::operator-->` (only C++ supports pre and post decrement) operations. They also have access to a limited set of additional functions, explained in the table below.
 
@@ -151,6 +151,6 @@ Related Links
 
 * User Guide Page: :ref:`Defining Environmental Properties<defining environmental properties>`
 * User Guide Page: :ref:`Host Functions: Accessing the Environment<host environment>`
-* User Guide Page: :ref:`What is SEATBELTS?<SEATBELTS>`
+* User Guide Page: :ref:`What is FLAMEGPU_SEATBELTS?<FLAMEGPU_SEATBELTS>`
 * Full API documentation for :class:`DeviceEnvironment<flamegpu::DeviceEnvironment>`
 * Full API documentation for :class:`DeviceMacroProperty<flamegpu::DeviceMacroProperty>`

--- a/src/guide/debugging-models/seatbelts.rst
+++ b/src/guide/debugging-models/seatbelts.rst
@@ -1,32 +1,32 @@
-.. _SEATBELTS:
+.. _FLAMEGPU_SEATBELTS:
 
-What is SEATBELTS?
-==================
+What is FLAMEGPU_SEATBELTS?
+===========================
 
 FLAME GPU 2, unlike FLAME GPU 1, allows models to be fully defined via a C++ API. This means that some algorithmic magic is required to map a variable's name to a memory within agent functions (CUDA device code) at runtime. In order to achieve this, whilst enabling the highest performance it becomes necessary to remove any safety checks (e.g. ensuring the variable exists, has the correct type etc).
 
-From this was born ``SEATBELTS``. Originally named ``NO_SEATBELTS`` after the racing concept of removing weight from a car to allow it to accelerate faster, in combination with the removal of safety checks which in the case of a racing car would be the seatbelts.
+From this was born ``FLAMEGPU_SEATBELTS``. Originally named ``NO_SEATBELTS`` after the racing concept of removing weight from a car to allow it to accelerate faster, in combination with the removal of safety checks which in the case of a racing car would be the seatbelts.
 
-When ``SEATBELTS`` is enabled at CMake configure time Release builds will include any error checking deemed expensive. These builds still run much faster than Debug builds, which always have ``SEATBELTS`` enabled regardless of CMAKE configuration. However, the fastest performance can only be achieved by producing a Release build with ``SEATBELTS`` disabled.
+When ``FLAMEGPU_SEATBELTS`` is enabled at CMake configure time Release builds will include any error checking deemed expensive. These builds still run much faster than Debug builds, which always have ``FLAMEGPU_SEATBELTS`` enabled regardless of CMAKE configuration. However, the fastest performance can only be achieved by producing a Release build with ``FLAMEGPU_SEATBELTS`` disabled.
 
-Most ``SEATBELTS`` checks are limited to device code within agent functions (type checking in host functions is cheap), however there are some additional expensive integrity checks (such as array message output collisions) which are limited to ``SEATBELTS`` enabled builds.
+Most ``FLAMEGPU_SEATBELTS`` checks are limited to device code within agent functions (type checking in host functions is cheap), however there are some additional expensive integrity checks (such as array message output collisions) which are limited to ``FLAMEGPU_SEATBELTS`` enabled builds.
 
 .. note::
 
-    CUDA does not support safely exiting device code early, via an exception or similar. All CUDA errors raised from device code execution are considered fatal, whereby the CUDA runtime is corrupted and data cannot be recovered from device memory. As such, in order to provide exceptions from agent functions, it is necessary for ``SEATBELTS`` to both log detail about the problem to device memory and return a sensible value (normally ``0``) in order to allow the agent function to complete without raising a CUDA error. Our testing has not found any cases where this currently fails, however it may be possible to structure code such that ``SEATBELTS`` does not prevent a CUDA error.
+    CUDA does not support safely exiting device code early, via an exception or similar. All CUDA errors raised from device code execution are considered fatal, whereby the CUDA runtime is corrupted and data cannot be recovered from device memory. As such, in order to provide exceptions from agent functions, it is necessary for ``FLAMEGPU_SEATBELTS`` to both log detail about the problem to device memory and return a sensible value (normally ``0``) in order to allow the agent function to complete without raising a CUDA error. Our testing has not found any cases where this currently fails, ho<SEATwever it may be possible to structure code such that ``FLAMEGPU_SEATBELTS`` does not prevent a CUDA error.
 
-Enabling/Disabling SEATBELTS
-----------------------------
-``SEATBELTS`` is a compile-time feature, whereby the compiler passes the C macro of the same name to all files. As such, it can only be toggled at CMake time (as mentioned above it cannot be disabled for Debug builds).
+Enabling/Disabling FLAMEGPU_SEATBELTS
+-------------------------------------
+``FLAMEGPU_SEATBELTS`` is a compile-time feature, whereby the compiler passes the C macro of the same name to all files. As such, it can only be toggled at CMake time (as mentioned above it cannot be disabled for Debug builds).
 
-By default when configuring CMake ``SEATBELTS`` is ``ON``.
+By default when configuring CMake ``FLAMEGPU_SEATBELTS`` is ``ON``.
 
-In order to disable it, for the fastest performance ``-DSEATBELTS=OFF`` must be passed to ``cmake`` at configure time. If using ``cmake-gui``, you should locate the ``SEATBELTS`` option in the central table, set it to ``OFF`` and press the ``Configure`` button followed by the ``Generate`` button.
+In order to disable it, for the fastest performance ``-DFLAMEGPU_SEATBELTS=OFF`` must be passed to ``cmake`` at configure time. If using ``cmake-gui``, you should locate the ``FLAMEGPU_SEATBELTS`` option in the central table, set it to ``OFF`` and press the ``Configure`` button followed by the ``Generate`` button.
 
 
-Understanding SEATBELTS Exceptions
-----------------------------------
-When ``SEATBELTS`` detects a problem in an agent function it will cause a :class:`DeviceError<flamegpu::exception::DeviceError>` to be raised. This error contains a message detailing the problem, for example:
+Understanding FLAMEGPU_SEATBELTS Exceptions
+-------------------------------------------
+When ``FLAMEGPU_SEATBELTS`` detects a problem in an agent function it will cause a :class:`DeviceError<flamegpu::exception::DeviceError>` to be raised. This error contains a message detailing the problem, for example:
 
 .. code-block:: none
 

--- a/src/guide/debugging-models/using-a-debugger.rst
+++ b/src/guide/debugging-models/using-a-debugger.rst
@@ -96,7 +96,7 @@ From here follows the normal ``cuda-gdb`` workflow, such as ``start`` (start the
 
 Python
 ~~~~~~
-In order to produce a debug build of pyflamegpu, it is necessary to specify ``-DCMAKE_BUILD_TYPE=Debug`` when configuring CMake. Additionally, you should pass ``-DEXPORT_RTC_SOURCES=ON``. When compiled this should produce a binary in the ``build/bin/Debug`` directory, and the compiled RTC sources will be exported to the working directory at runtime.
+In order to produce a debug build of pyflamegpu, it is necessary to specify ``-DCMAKE_BUILD_TYPE=Debug`` when configuring CMake. Additionally, you should pass ``-DFLAMEGPU_RTC_EXPORT_SOURCES=ON``. When compiled this should produce a binary in the ``build/bin/Debug`` directory, and the compiled RTC sources will be exported to the working directory at runtime.
 
 .. note::
 

--- a/src/guide/defining-messages-communication/index.rst
+++ b/src/guide/defining-messages-communication/index.rst
@@ -167,7 +167,7 @@ Array Specialisation
 
 Array messages work similarly to an array. When an array message type is defined, it's dimensions must be specified. Agents can then output a message to a single unique element within the array.
 
-Multiple agents must not output messages to the same element, if ``SEATBELTS`` error checking is enabled this will be detected and an exception raised.
+Multiple agents must not output messages to the same element, if ``FLAMEGPU_SEATBELTS`` error checking is enabled this will be detected and an exception raised.
 
 Elements which do not have a message output will return ``0`` for all variables, similar to if an agent does not set all variables of a message it outputs.
 
@@ -207,7 +207,7 @@ Related Links
 ^^^^^^^^^^^^^
 
 * User Guide Page: :ref:`Agent Communication<Device Agent Communication>`
-* User Guide Page: :ref:`What is SEATBELTS?<SEATBELTS>`
+* User Guide Page: :ref:`What is FLAMEGPU_SEATBELTS?<FLAMEGPU_SEATBELTS>`
 * Full API documentation for :class:`MessageBruteForce::Description<flamegpu::MessageBruteForce::Description>`
 * Full API documentation for :class:`MessageBucket::Description<flamegpu::MessageBucket::Description>`
 * Full API documentation for :class:`MessageSpatial2D::Description<flamegpu::MessageSpatial2D::Description>`

--- a/src/guide/flamegpu2-source/contribute.rst
+++ b/src/guide/flamegpu2-source/contribute.rst
@@ -30,7 +30,7 @@ Please adhere to the :ref:`Coding Conventions` used throughout the project (inde
 
 Before merging pull requests are required to pass all continuous integration:
 
-* The full codebase should build with the ``WARNINGS_AS_ERRORS`` option enabled under the provided CMake configuration, on both Windows and Linux.
+* The full codebase should build with the ``FLAMEGPU_DOCS_WARNINGS_AS_ERRORS`` option enabled under the provided CMake configuration, on both Windows and Linux.
 * The full test suite should pass.
 * ``cpplint`` should report no issues, using ``CPPLINT.cfg`` found in the root of the project.
 

--- a/src/guide/performance-troubleshooting/index.rst
+++ b/src/guide/performance-troubleshooting/index.rst
@@ -1,7 +1,7 @@
 Performance Troubleshooting
 ===========================
 
-For the best performance you should be using a Release build of FLAME GPU 2 and your model, with ``SEATBELTS`` set to ``OFF`` at CMake configure time. These runtime checks can be very expensive, so they are best disabled after development when high-performance is required.
+For the best performance you should be using a Release build of FLAME GPU 2 and your model, with ``FLAMEGPU_SEATBELTS`` set to ``OFF`` at CMake configure time. These runtime checks can be very expensive, so they are best disabled after development when high-performance is required.
 
 
 

--- a/src/guide/visualisation/building-with-vis.rst
+++ b/src/guide/visualisation/building-with-vis.rst
@@ -3,7 +3,7 @@ Enabling Visualisation
 
 To use the visualisation features you must ensure that you are using a build of FLAME GPU with visualisation enabled.
 
-Visualisation is enabled by setting the ``VISUALISATION`` CMake option to ``ON`` during CMake Configuration. See  :ref:`building-flamegpu-from-source`.
+Visualisation is enabled by setting the ``FLAMEGPU_VISUALISATION`` CMake option to ``ON`` during CMake Configuration. See  :ref:`building-flamegpu-from-source`.
 
 Once visualisation support is enabled, it is still necessary to provide some configuration in order to select which agents to visualise and how.
 
@@ -18,7 +18,7 @@ FLAME GPU visualisation support can be detected within models:
 
   .. code-tab:: cpp C++
 
-    #ifdef VISUALISATION
+    #ifdef FLAMEGPU_VISUALISATION
         // Visualisation specific code
     #endif
 

--- a/src/guide/visualisation/setting-up-vis.rst
+++ b/src/guide/visualisation/setting-up-vis.rst
@@ -12,7 +12,7 @@ To create a FLAME GPU visualisation, you must configure and activate the visuali
     // Create CUDASimulation as normal
     flamegpu::CUDASimulation cudaSimulation(model);
     // Only enable vis if visualisation support is present
-    #ifdef VISUALISATION
+    #ifdef FLAMEGPU_VISUALISATION
         // Configure the visualisation
         flamegpu::visualiser::ModelVis visualisation = cudaSimulation.getVisualisation();
         ...
@@ -86,7 +86,7 @@ If you would prefer to prevent this, and keep the visualisation open, so the fin
     // Execute simulation
     cudaSimulation.simulate();
     // Join the visualisation after simulation returns to prevent the window closing
-    #ifdef VISUALISATION
+    #ifdef FLAMEGPU_VISUALISATION
         visualisation.join();
     #endif
 

--- a/src/quickstart/index.rst
+++ b/src/quickstart/index.rst
@@ -94,13 +94,13 @@ For example, to build the ``example`` target of the template repository, for Com
   .. code-tab:: bash Linux
 
        mkdir -p build && cd build
-       cmake .. -DCUDA_ARCH=61 -DCMAKE_BUILD_TYPE=Release
+       cmake .. -DCMAKE_CUDA_ARCHITECTURES=61 -DCMAKE_BUILD_TYPE=Release
        cmake --build . --target example -j 8
        
   .. code-tab:: bat Windows
 
      mkdir build && cd build
-     cmake .. -A x64 -G "Visual Studio 16 2019" -DCUDA_ARCH=61
+     cmake .. -A x64 -G "Visual Studio 16 2019" -CMAKE_CUDA_ARCHITECTURES=61
      cmake --build . --target example --config Release -j 8
 
 For more information on CMake Configuration options please see the `template repository README.md <https://github.com/FLAMEGPU/FLAMEGPU2-example-template#building-with-cmake>`__ as these options may vary between releases.
@@ -223,7 +223,7 @@ FLAME GPU 2 uses CMake with out-of-source builds. This is a 3 step process:
 
 3. Build compilation targets using the configured build system
 
-To build the python bindings, the ``BUILD_SWIG_PYTHON`` CMake option must be set to ``ON``, and the ``pyflamegpu`` target must be compiled. The generated python binary wheel can then be installed into your python environment of choice via `pip`
+To build the python bindings, the ``FLAMEGPU_BUILD_PYTHON`` CMake option must be set to ``ON``, and the ``pyflamegpu`` target must be compiled. The generated python binary wheel can then be installed into your python environment of choice via `pip`
 
 For example, to build and install python bindings into a new venv, for Compute Capability 6.0 GPUs in the Release configuration, using 8 threads:
 
@@ -237,7 +237,7 @@ For example, to build and install python bindings into a new venv, for Compute C
 
        # Build the python bindings, producing a .whl
        mkdir -p build && cd build
-       cmake .. -DCUDA_ARCH=61 -DBUILD_SWIG_PYTHON=ON -DCMAKE_BUILD_TYPE=Release
+       cmake .. -DCMAKE_CUDA_ARCHITECTURES=61 -DFLAMEGPU_BUILD_PYTHON=ON -DCMAKE_BUILD_TYPE=Release
        cmake --build . --target pyflamegpu -j 8
 
        # Install the wheel via pip
@@ -251,7 +251,7 @@ For example, to build and install python bindings into a new venv, for Compute C
 
        :: Build the python bindings, producing a .whl
        mkdir build && cd build
-       cmake .. -A x64 -G "Visual Studio 16 2019" -DCUDA_ARCH=61 -DBUILD_SWIG_PYTHON=ON
+       cmake .. -A x64 -G "Visual Studio 16 2019" -DCMAKE_CUDA_ARCHITECTURES=61 -DFLAMEGPU_BUILD_PYTHON=ON
        cmake --build . --target pyflamegpu --config Release -j 8
 
        :: Install the wheel via pip

--- a/src/tutorial/index.rst
+++ b/src/tutorial/index.rst
@@ -110,7 +110,7 @@ A more detailed guide, regarding building FLAME GPU 2 from source can be found :
     mkdir -p build && cd build
 
     # Configure CMake from the command line passing configure-time options. 
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCUDA_ARCH=61
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=61
 
   .. code-tab:: bat Windows (.bat)
   
@@ -119,7 +119,7 @@ A more detailed guide, regarding building FLAME GPU 2 from source can be found :
     cd build
 
     :: Configure CMake from the command line, specifying the -A and -G options. Alternatively use the GUI (see Quickstart guide)
-    cmake .. -A x64 -G "Visual Studio 16 2019" -DCUDA_ARCH=61
+    cmake .. -A x64 -G "Visual Studio 16 2019" -DCMAKE_CUDA_ARCHITECTURES=61
 
     :: You can then open Visual Studio manually from the .sln file, or via:
     cmake --open . 
@@ -127,7 +127,7 @@ A more detailed guide, regarding building FLAME GPU 2 from source can be found :
 
 .. note::
   
-  ``-DCUDA_ARCH=61``, configures the build for Pascal GPUs of ``SM_61``, you may wish to change this to match your available GPU. Omitting it entirely will produce a larger binary suitable for all current architectures, which essentially multiplies the compile time by the number of architectures. In general, GPUs of newer architecture than specified will run but be limited to the features of the earlier architecture that the program was compiled for.
+  ``-DCMAKE_CUDA_ARCHITECTURES=61``, configures the build for Pascal GPUs of ``SM_61``, you may wish to change this to match your available GPU. Omitting it entirely will produce a larger binary suitable for all current architectures, which essentially multiplies the compile time by the number of architectures. In general, GPUs of newer architecture than specified will run but be limited to the features of the earlier architecture that the program was compiled for.
 
 
 The build files for the project should now be created inside the directory ``build``.
@@ -389,7 +389,7 @@ To read an agent's variables the :func:`FLAMEGPU->getVariable()<template<typenam
 
 Functionality for the message output is accessed via ``FLAMEGPU->message_out`` (or named ``message_out`` variable in Agent Python), this object is specialised depending on the output message type originally specified in the :c:macro:`FLAMEGPU_AGENT_FUNCTION<FLAMEGPU_AGENT_FUNCTION>` macro (or via the Python type annotation). The spatial 2D specialisation, :class:`flamegpu::MessageSpatial2D::Out`, has two available functions; :func:`setVariable()<template<typename T, unsigned int N> __device__ void flamegpu::MessageBruteForce::Out::setVariable(const char(&)[N], T) const>` which is common to all message output types, and :func:`setLocation()<flamegpu::MessageSpatial2D::Out::setLocation>` which takes two ``float`` arguments specifying the location of the message in 2D space. The Python equivalents are of the same format as in other places (e.g. ``setVariableInt`` for the ``int`` type).
 
-Finally, all agent functions must return either :enumerator:`flamegpu::ALIVE<flamegpu::AGENT_STATUS::ALIVE>` or :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` (``pyflamegpu.ALIVE`` or ``pyflamegpu.DEAD`` respectively in Agent Python). Unless the agent function is specified to support agent death inside the :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` via :func:`setAllowAgentDeath()<flamegpu::AgentFunctionDescription::setAllowAgentDeath>`, :enumerator:`flamegpu::ALIVE<flamegpu::AGENT_STATUS::ALIVE>` should be returned. If :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` is returned, without agent death being enabled, an exception will be raised if ``SEATBELTS`` error checking is enabled.
+Finally, all agent functions must return either :enumerator:`flamegpu::ALIVE<flamegpu::AGENT_STATUS::ALIVE>` or :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` (``pyflamegpu.ALIVE`` or ``pyflamegpu.DEAD`` respectively in Agent Python). Unless the agent function is specified to support agent death inside the :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>` via :func:`setAllowAgentDeath()<flamegpu::AgentFunctionDescription::setAllowAgentDeath>`, :enumerator:`flamegpu::ALIVE<flamegpu::AGENT_STATUS::ALIVE>` should be returned. If :enumerator:`flamegpu::DEAD<flamegpu::AGENT_STATUS::DEAD>` is returned, without agent death being enabled, an exception will be raised if ``FLAMEGPU_SEATBELTS`` error checking is enabled.
 
     
 
@@ -845,7 +845,7 @@ In most cases, you will want the visualisation to persist after the simulation c
 
 .. note::
     
-    FLAME GPU is designed for use both on personal machines and headless machines over ssh (e.g. HPC). The latter are unlikely to have support for visualisations, as such FLAME GPU can be built without visualisation support. Hence, it is useful to wrap the visualisation specific code with a check for the ``VISUALISATION`` macro, allowing the model to compile/run irrespective of visualisation support as opposed to maintaining two versions.
+    FLAME GPU is designed for use both on personal machines and headless machines over ssh (e.g. HPC). The latter are unlikely to have support for visualisations, as such FLAME GPU can be built without visualisation support. Hence, it is useful to wrap the visualisation specific code with a check for the ``FLAMEGPU_VISUALISATION`` macro, allowing the model to compile/run irrespective of visualisation support as opposed to maintaining two versions.
 
 
 .. tabs::
@@ -855,7 +855,7 @@ In most cases, you will want the visualisation to persist after the simulation c
     ... // following on from flamegpu::CUDASimulation cuda_model(model, argc, argv);
         
     // Only compile this block if being built with visualisation support    
-    #ifdef VISUALISATION
+    #ifdef FLAMEGPU_VISUALISATION
         // Create visualisation
         flamegpu::visualiser::ModelVis m_vis = cuda_model.getVisualisation();
         // Set the initial camera location and speed
@@ -883,7 +883,7 @@ In most cases, you will want the visualisation to persist after the simulation c
         // Run the simulation
         cuda_model.simulate();
         
-    #ifdef VISUALISATION
+    #ifdef FLAMEGPU_VISUALISATION
         // Keep the visualisation window active after the simulation has completed
         m_vis.join();
     #endif
@@ -1081,7 +1081,7 @@ If you have followed the complete tutorial, you should now have the following co
           cuda_model.setStepLog(step_log_cfg);
           
       // Only compile this block if being built with visualisation support
-      #ifdef VISUALISATION
+      #ifdef FLAMEGPU_VISUALISATION
           // Create visualisation
           flamegpu::visualiser::ModelVis m_vis = cuda_model.getVisualisation();
           // Set the initial camera location and speed
@@ -1109,7 +1109,7 @@ If you have followed the complete tutorial, you should now have the following co
           // Run the simulation
           cuda_model.simulate();
           
-      #ifdef VISUALISATION
+      #ifdef FLAMEGPU_VISUALISATION
           // Keep the visualisation window active after the simulation has completed
           m_vis.join();
       #endif
@@ -1438,4 +1438,4 @@ If you have followed the complete tutorial, you should now have the following co
 Related Links
 -------------
 
-* User Guide Page: :ref:`What is SEATBELTS?<SEATBELTS>`
+* User Guide Page: :ref:`What is FLAMEGPU_SEATBELTS?<FLAMEGPU_SEATBELTS>`


### PR DESCRIPTION
Changes required due to https://github.com/FLAMEGPU/FLAMEGPU2/pull/991.

Includes prefixing CMake options with `FLAMEGPU_`, use of renamed cmake functions (prefixed `flamegpu_`), prefixed compiler definitions with `FLAMEGPU_` and the change to use `CMAKE_CUDA_ARCHITECTURES` in place of `CUDA_ARCH`.

Now that https://github.com/FLAMEGPU/FLAMEGPU2/pull/991 has been merged, and this repository is only concerned with current master, any CI jobs (or local builds which fetch the main repository) will fail. until this PR is merged. 
