### PR TITLE
Remove 'Callback' from Python host fn method/class names.

### DIFF
--- a/src/guide/creating-a-model/index.rst
+++ b/src/guide/creating-a-model/index.rst
@@ -68,8 +68,4 @@ The :class:`ModelDescription<flamegpu::ModelDescription>` class has various meth
   
     :func:`newMessage()<flamegpu::ModelDescription::newMessage>` take a template argument, so it is called in the format ``newMessage<flamegpu::MessageBruteForce>()``. As the Python API lacks templates, they are instead called in the format ``newMessageBruteForce()``.
 
-.. note::
-  
-    The host function methods e.g. :func:`addInitFunction()<flamegpu::ModelDescription::addInitFunction>`, :func:`addExitCondition()<flamegpu::ModelDescription::addExitCondition>` etc are named slightly different in the Python API. Instead they are called ``addInitFunctionCallback()``, ``addExitConditionCallback()`` etc.
-
 The subsequent chapters of this guide explore their usage in greater detail.

--- a/src/guide/debugging-models/logging.rst
+++ b/src/guide/debugging-models/logging.rst
@@ -140,7 +140,7 @@ A step function must also be added, to both copy the macro property to the envir
     
   .. code-tab:: py Python
     
-    class reset_counters(pyflamegpu.HostFunctionCallback):
+    class reset_counters(pyflamegpu.HostFunction):
         def run(self,FLAMEGPU):
             # Copy the data from macro environment property to environment property
             NB_COUNT = FLAMEGPU.agent("NB").count()
@@ -151,7 +151,7 @@ A step function must also be added, to both copy the macro property to the envir
             nb_cycle_counter.zero()
             
     // Attach the step function to the model
-    model.addStepFunctionCallback(reset_counters())
+    model.addStepFunction(reset_counters())
 
 Now the agent function can be updated to increment the counters at each branch
 

--- a/src/guide/defining-execution-order/dependency-graph.rst
+++ b/src/guide/defining-execution-order/dependency-graph.rst
@@ -103,7 +103,7 @@ In order to add a host layer function to the dependency graph, a :class:`HostFun
   .. code-tab:: py Python
 
     # Define a host function called host_fn1
-    class host_fn1(pyflamegpu.HostFunctionCallback):
+    class host_fn1(pyflamegpu.HostFunction):
       '''
          The explicit __init__() is optional, however if used the superclass __init__() must be called
       '''

--- a/src/guide/defining-execution-order/exit-conditions.rst
+++ b/src/guide/defining-execution-order/exit-conditions.rst
@@ -31,7 +31,7 @@ In particular, submodels which are introduced in the :ref:`following section<Def
 
   .. code-tab:: py Python
 
-    class my_exit_condition(pyflamegpu.HostFunctionConditionCallback):
+    class my_exit_condition(pyflamegpu.HostCondition):
         def run(self, FLAMEGPU):
             # A simple exit condition which forces the model to exit after 100 steps
             if FLAMEGPU.getStepCounter() >= 100: 
@@ -44,7 +44,7 @@ In particular, submodels which are introduced in the :ref:`following section<Def
     ...
     
     # Add 'my_exit_condition' to 'model'
-    model.addExitConditionCallback(my_exit_condition())
+    model.addExitCondition(my_exit_condition())
 
 If a model has multiple exit conditions, they will be executed in the order that they were added to the model. 
 When multiple exit conditions are defined, conditions are only executed if earlier exit condition functions return :enumerator:`CONTINUE<flamegpu::CONDITION_RESULT::CONTINUE>`.
@@ -54,5 +54,5 @@ Related Links
 * User Guide Page: :ref:`Host Functions and Conditions<Host Functions and Conditions>`
 * User Guide Page: :ref:`Configuring Execution<Configuring Execution>`
 * User Guide Page: :ref:`Submodels<Defining a Submodel>`
-* Full API documentation for :c:macro:`FLAMEGPU_EXIT_CONDITION` (Python: :class:`HostFunctionConditionCallback<flamegpu::HostFunctionConditionCallback>`)
+* Full API documentation for :c:macro:`FLAMEGPU_EXIT_CONDITION` (Python: :class:`HostCondition<flamegpu::HostConditionCallback>`)
 * Full API documentation for :enum:`flamegpu::CONDITION_RESULT<flamegpu::CONDITION_RESULT>` (:enumerator:`CONTINUE<flamegpu::CONDITION_RESULT::CONTINUE>` and :enumerator:`EXIT<flamegpu::CONDITION_RESULT::EXIT>`

--- a/src/guide/defining-execution-order/layers.rst
+++ b/src/guide/defining-execution-order/layers.rst
@@ -16,7 +16,7 @@ Manual Layer Specification
 
 :func:`newLayer()<flamegpu::ModelDescription::newLayer>` is called on the :class:`ModelDescription<flamegpu::ModelDescription>` to create a new :class:`LayerDescription<flamegpu::LayerDescription>`. Layers will execute in the order that they are created.
 
-Agent functions, host functions, and submodels can then be added to layers via their respective methods: :func:`addAgentFunction()<flamegpu::LayerDescription::addAgentFunction>`, :func:`addHostFunction()<flamegpu::LayerDescription::addHostFunction>` (Python: ``addHostFunctionCallback()``) and :func:`addSubModel()<flamegpu::LayerDescription::addSubModel>`. To each of these you pass the respective description object, alternatively for agent and host functions you can pass their raw function handles that were used to create the functions (this won't work for agent function definitions used by multiple agents).
+Agent functions, host functions, and submodels can then be added to layers via their respective methods: :func:`addAgentFunction()<flamegpu::LayerDescription::addAgentFunction>`, :func:`addHostFunction()<flamegpu::LayerDescription::addHostFunction>` (Python: ``addHostFunction()``) and :func:`addSubModel()<flamegpu::LayerDescription::addSubModel>`. To each of these you pass the respective description object, alternatively for agent and host functions you can pass their raw function handles that were used to create the functions (this won't work for agent function definitions used by multiple agents).
 
 The below example demonstrates adding an agent and host function to separate layers.
   
@@ -50,7 +50,7 @@ The below example demonstrates adding an agent and host function to separate lay
         return flamegpu::ALIVE;
     }
     """
-    class validation(pyflamegpu.HostFunctionCallback):
+    class validation(pyflamegpu.HostFunction):
         def run(self, FLAMEGPU):
             # Do something
     }
@@ -66,7 +66,7 @@ The below example demonstrates adding an agent and host function to separate lay
     layer.addAgentFunction(outputdata_desc)
     
     # Create a new layer for the host function 'validation'
-    model.newLayer().addHostFunctionCallback(validation())
+    model.newLayer().addHostFunction(validation())
 
 
 Layer Specification Rules

--- a/src/guide/defining-execution-order/submodels.rst
+++ b/src/guide/defining-execution-order/submodels.rst
@@ -66,7 +66,7 @@ When calling :func:`bindAgent()<flamegpu::SubModelDescription::bindAgent>`, it i
       s_af1 = s_a.newRTCFunction("example_function", ExampleFn)
       sub_m.newLayer().addFunction(s_af1)
       # Give the model an exit condition, this is required for all submodels
-      sub_m.addExitConditionCallback(ExitCdn());
+      sub_m.addExitCondition(ExitCdn());
 
       # Define the parent model
       m = pyflamegpu.ModelDescription("model")
@@ -139,5 +139,5 @@ Related Links
 * Full API documentation for :class:`SubModelDescription<flamegpu::SubModelDescription>`
 * Full API documentation for :class:`SubAgentDescription<flamegpu::SubAgentDescription>`
 * Full API documentation for :class:`SubEnvironmentDescription<flamegpu::SubEnvironmentDescription>`
-* Full API documentation for :c:macro:`FLAMEGPU_HOST_CONDITION` (Python: :class:`HostFunctionConditionCallback<flamegpu::HostFunctionConditionCallback>`)
+* Full API documentation for :c:macro:`FLAMEGPU_HOST_CONDITION` (Python: :class:`HostCondition<flamegpu::HostConditionCallback>`)
 * Full API documentation for :class:`ModelDescription<flamegpu::ModelDescription>`

--- a/src/guide/host-functions/agent-operations.rst
+++ b/src/guide/host-functions/agent-operations.rst
@@ -18,7 +18,7 @@ Host agent operations are performed on a single agent state, via :class:`HostAge
 
   .. code-tab:: py Python
   
-    class example_agent_hostfn(pyflamegpu.HostFunctionCallback):
+    class example_agent_hostfn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Retrieve the host agent tools for agent sheep in the default state
         sheep = FLAMEGPU.agent("sheep");
@@ -90,7 +90,7 @@ The C++ interface optionally allows the output type for ``sum`` and ``histogramE
   .. code-tab:: py Python
   
     # Define an host function called reduce_hostfn
-    class reduce_hostfn(pyflamegpu.HostFunctionCallback):
+    class reduce_hostfn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Retrieve the host agent tools for agent sheep in the default state
         sheep = FLAMEGPU.agent("sheep");
@@ -152,7 +152,7 @@ Agent populations can also be sorted according to a variable, the C++ API can ad
 
   .. code-tab:: py Python
     
-    class reduce_hostfn(pyflamegpu.HostFunctionCallback):
+    class reduce_hostfn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Retrieve the host agent tools for agent sheep in the default state
         sheep = FLAMEGPU.agent("sheep");
@@ -191,7 +191,7 @@ It's also possible to create new agents with the :class:`HostAgentAPI<flamegpu::
 
   .. code-tab:: py Python
     
-    class CreateNewSheep(pyflamegpu.HostFunctionCallback):
+    class CreateNewSheep(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Retrieve the host agent tools for agent sheep in the default state
         sheep = FLAMEGPU.agent("sheep");
@@ -226,7 +226,7 @@ For raw access to agent data, :class:`DeviceAgentVector<flamegpu::DeviceAgentVec
     
   .. code-tab:: python
 
-    class deviceagentvector_hostfn(pyflamegpu.HostFunctionCallback):
+    class deviceagentvector_hostfn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Retrieve the host agent tools for agent sheep in the default state
         sheep = FLAMEGPU.agent("sheep")
@@ -256,7 +256,7 @@ For raw access to agent data, :class:`DeviceAgentVector<flamegpu::DeviceAgentVec
     
   .. code-tab:: python
 
-    class deviceagentvector_hostfn(pyflamegpu.HostFunctionCallback):
+    class deviceagentvector_hostfn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Retrieve the host agent tools for agent sheep in the default state
         sheep = FLAMEGPU.agent("sheep")

--- a/src/guide/host-functions/defining-host-functions.rst
+++ b/src/guide/host-functions/defining-host-functions.rst
@@ -7,7 +7,7 @@ Unlike agent functions, host Functions are implemented natively, in C++ if using
 
 In the C++ API a host function is defined using the :c:macro:`FLAMEGPU_HOST_FUNCTION` macro, similarly a host condition is defined using the :c:macro:`FLAMEGPU_HOST_CONDITION`. This takes a single argument, a unique name identifying the function.
 
-In the Python API a host function is defined as a subclass of :class:`HostFunctionCallback<flamegpu::HostFunctionCallback>`, similarly a host condition is defined as a subclass of :class:`HostFunctionConditionCallback<flamegpu::HostFunctionConditionCallback>`.
+In the Python API a host function is defined as a subclass of :class:`HostFunction<flamegpu::HostFunctionCallback>`, similarly a host condition is defined as a subclass of :class:`HostCondition<flamegpu::HostConditionCallback>`.
 
 
 .. tabs::
@@ -28,7 +28,7 @@ In the Python API a host function is defined as a subclass of :class:`HostFuncti
   .. code-tab:: py Python
 
     # Define a host function called host_fn1
-    class host_fn1(pyflamegpu.HostFunctionCallback):
+    class host_fn1(pyflamegpu.HostFunction):
       '''
          The explicit __init__() is optional, however if used the superclass __init__() must be called
       '''
@@ -40,7 +40,7 @@ In the Python API a host function is defined as a subclass of :class:`HostFuncti
         
         
     # Define a host condition called host_cdn1
-    class host_cdn1(pyflamegpu.HostFunctionConditionCallback):
+    class host_cdn1(pyflamegpu.HostCondition):
       '''
          The explicit __init__() is optional, however if used the superclass __init__() must be called
       '''
@@ -87,15 +87,15 @@ Adding Host Functions to a Model
 Host functions and conditions are predominantly added to a model via their respective methods on :class:`ModelDescription<flamegpu::ModelDescription>`. They will execute in the order in which they are added.
 The exception to this rule are host-layer functions, details on how to specify their position in the execution order can be found :ref:`here<Execution Order>`.
 
-======================== ========================================================================= =======================================================================
-Type                     C++ Method                                                                Python Method
-======================== ========================================================================= =======================================================================
-Initialisation Function  :func:`addInitFunction()<flamegpu::ModelDescription::addInitFunction>`    :func:`addInitFunctionCallback()<flamegpu::ModelDescription::addInitFunctionCallback>`
-Exit Function            :func:`addStepFunction()<flamegpu::ModelDescription::addStepFunction>`    :func:`addStepFunctionCallback()<flamegpu::ModelDescription::addStepFunctionCallback>`
-Step Function            :func:`addExitFunction()<flamegpu::ModelDescription::addExitFunction>`    :func:`addExitFunctionCallback()<flamegpu::ModelDescription::addExitFunctionCallback>`
-Host-Layer Function      :ref:`n/a<Execution Order>`                                               :ref:`n/a<Execution Order>`
-Exit Condition           :func:`addExitCondition()<flamegpu::ModelDescription::addExitCondition>`  :func:`addExitConditionCallback()<flamegpu::ModelDescription::addExitConditionCallback>`
-======================== ========================================================================= =======================================================================
+======================== =========================================================================
+Type                     Method
+======================== =========================================================================
+Initialisation Function  :func:`addInitFunction()<flamegpu::ModelDescription::addInitFunction>`
+Exit Function            :func:`addStepFunction()<flamegpu::ModelDescription::addStepFunction>`
+Step Function            :func:`addExitFunction()<flamegpu::ModelDescription::addExitFunction>`
+Host-Layer Function      :ref:`n/a<Execution Order>`
+Exit Condition           :func:`addExitCondition()<flamegpu::ModelDescription::addExitCondition>`
+======================== =========================================================================
 
 The below example shows how an init function would be added to a model:
 
@@ -120,7 +120,7 @@ The below example shows how an init function would be added to a model:
   .. code-tab:: py Python
 
     # Define a host function called init_fn
-    class init_fn(pyflamegpu.HostFunctionCallback):
+    class init_fn(pyflamegpu.HostFunction):
       '''
          The explicit __init__() is optional, however if used the superclass __init__() must be called
       '''
@@ -136,7 +136,7 @@ The below example shows how an init function would be added to a model:
     model = pyflamegpu.ModelDescription("Test Model")
     ... # Rest of model definition
     # Add the exit function init_fn to Test Model
-    model.addInitFunctionCallback(init_fn())
+    model.addInitFunction(init_fn())
     ...
 
 
@@ -145,8 +145,8 @@ Related Links
 * Full API documentation for :c:macro:`FLAMEGPU_INIT_FUNCTION`
 * Full API documentation for :c:macro:`FLAMEGPU_EXIT_FUNCTION`
 * Full API documentation for :c:macro:`FLAMEGPU_STEP_FUNCTION`
-* Full API documentation for :c:macro:`FLAMEGPU_HOST_FUNCTION` (Python: :class:`HostFunctionCallback<flamegpu::HostFunctionCallback>`)
+* Full API documentation for :c:macro:`FLAMEGPU_HOST_FUNCTION` (Python: :class:`HostFunction<flamegpu::HostFunctionCallback>`)
 * Full API documentation for :c:macro:`FLAMEGPU_EXIT_CONDITION`
-* Full API documentation for :c:macro:`FLAMEGPU_HOST_CONDITION` (Python: :class:`HostFunctionConditionCallback<flamegpu::HostFunctionConditionCallback>`)
+* Full API documentation for :c:macro:`FLAMEGPU_HOST_CONDITION` (Python: :class:`HostCondition<flamegpu::HostConditionCallback>`)
 * Full API documentation for :class:`ModelDescription<flamegpu::ModelDescription>`
 * Full API documentation for :class:`LayerDescription<flamegpu::LayerDescription>`

--- a/src/guide/host-functions/interacting-with-environment.rst
+++ b/src/guide/host-functions/interacting-with-environment.rst
@@ -40,7 +40,7 @@ Environmental properties are accessed, using :class:`HostEnvironment<flamegpu::H
 
   .. code-tab:: py Python
 
-    class ExampleHostFn(pyflamegpu.HostFunctionCallback):
+    class ExampleHostFn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Get the value of scalar environment property 'scalar_f' and store it in local variable 'scalar_f'
         scalar_f = FLAMEGPU.environment.getPropertyFloat("scalar_f")
@@ -86,7 +86,7 @@ Environmental macro properties can be read via the returned :class:`HostMacroPro
   .. code-tab:: python
   
     # Define an host function called read_env_hostfn
-    class read_env_hostfn(pyflamegpu.HostFunctionCallback):
+    class read_env_hostfn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
         # Retrieve the environment macro property foo of type float
         foo = FLAMEGPU->environment.getMacroPropertyFloat("foo");
@@ -123,7 +123,7 @@ Below are several examples of how environment macro properties can be updated in
   .. code-tab:: python
   
     # Define an host function called write_env_hostfn
-    class write_env_hostfn(pyflamegpu.HostFunctionCallback):
+    class write_env_hostfn(pyflamegpu.HostFunction):
       def run(self,FLAMEGPU):
       # Retrieve the environment macro property foo of type float
       foo = FLAMEGPU->environment.getMacroPropertyFloat("foo");

--- a/src/guide/host-functions/random-numbers.rst
+++ b/src/guide/host-functions/random-numbers.rst
@@ -33,7 +33,7 @@ When calling any of these methods the type must be specified. Most methods only 
   .. code-tab:: py python
   
     # Define an host function called random_hostfn
-    class random_hostfn(pyflamegpu.HostFunctionCallback):
+    class random_hostfn(pyflamegpu.HostFunction):
       def run(self, FLAMEGPU):
         # Generate a uniform random float [0, 1)
         uniform_float = FLAMEGPU.random.uniformFloat()
@@ -63,7 +63,7 @@ Additionally the :class:`HostAPI<flamegpu::HostAPI>` random object has the abili
   .. code-tab:: py python
   
     # Define an host function called random_hostfn2
-    class random_hostfn2(pyflamegpu.HostFunctionCallback):
+    class random_hostfn2(pyflamegpu.HostFunction):
       def run(self, FLAMEGPU):
         # Retrieve the current random seed
         old_seed = FLAMEGPU.random.getSeed()

--- a/src/tutorial/index.rst
+++ b/src/tutorial/index.rst
@@ -667,7 +667,7 @@ Now that the model's components and behaviours have been setup, it's time to dec
 
 For the Circles model, we simply need to randomly scatter an amount of agents within the environment bounds. Therefore, we can simply generate agents according to some of the environment properties we defined earlier.
 
-Similar to agent functions, the C++ API defines initialisation functions using :c:macro:`FLAMEGPU_INIT_FUNCTION`, which takes a single argument of the function's name. Python in contrast has native functions, so they are defined differently, a subclass of ``pyflamegpu.HostFunctionCallback`` must be created, which implements the method ``def run(self, FLAMEGPU):``.
+Similar to agent functions, the C++ API defines initialisation functions using :c:macro:`FLAMEGPU_INIT_FUNCTION`, which takes a single argument of the function's name. Python in contrast has native functions, so they are defined differently, a subclass of ``pyflamegpu.HostFunction`` must be created, which implements the method ``def run(self, FLAMEGPU):``.
 
 Initialisation function's have access to the :class:`HostAPI<flamegpu::HostAPI>`, the host counter-part to the :class:`DeviceAPI<flamegpu::DeviceAPI>` present in agent functions. It has similar functionality, with a few additional features: agent variable reductions, setting environment properties.
 
@@ -702,7 +702,7 @@ Putting all this together, we can use the below code to generate the initial age
   .. code-tab:: py Python
 
     ...   
-    class create_agents(pyflamegpu.HostFunctionCallback):
+    class create_agents(pyflamegpu.HostFunction):
         def run(self, FLAMEGPU):
             # Fetch the desired agent count and environment width
             AGENT_COUNT = FLAMEGPU.environment.getPropertyUInt("AGENT_COUNT")
@@ -720,7 +720,7 @@ Putting all this together, we can use the below code to generate the initial age
     
     Use of the FLAME GPU random API in initialisation functions, ensure that the random (and hence the model) is seeded according to the random seed specified for the simulation at execution.
     
-Similar to agent functions, the initialisation function must be attached to the model. Initialisation function's always run once at the start of the model, so it's not necessary to use layer or a dependency graph, they are simply added to the :class:`ModelDescription<flamegpu::ModelDescription>` using :func:`addInitFunction()<flamegpu::ModelDescription::addInitFunction>` (C++ API) or ``addInitFunctionCallback()`` (Python API).
+Similar to agent functions, the initialisation function must be attached to the model. Initialisation function's always run once at the start of the model, so it's not necessary to use layer or a dependency graph, they are simply added to the :class:`ModelDescription<flamegpu::ModelDescription>` using :func:`addInitFunction()<flamegpu::ModelDescription::addInitFunction>` (C++ API) or ``addInitFunction()`` (Python API).
 
 .. tabs::
 
@@ -734,7 +734,7 @@ Similar to agent functions, the initialisation function must be attached to the 
 
     ...
     dependencyGraph.generateLayers(model)
-    model.addInitFunctionCallback(create_agents())
+    model.addInitFunction(create_agents())
     ...
     
 
@@ -804,7 +804,7 @@ After the :class:`StepLoggingConfig<flamegpu::StepLoggingConfig>` is fully defin
 
   .. code-tab:: py Python
   
-    ... # following on from model.addInitFunctionCallback(create_agents())
+    ... # following on from model.addInitFunction(create_agents())
     
     # Specify the desired StepLoggingConfig
     step_log_cfg = pyflamegpu.StepLoggingConfig(model)
@@ -1170,7 +1170,7 @@ If you have followed the complete tutorial, you should now have the following co
       }
       """
 
-      class create_agents(pyflamegpu.HostFunctionCallback):
+      class create_agents(pyflamegpu.HostFunction):
           def run(self, FLAMEGPU):
               # Fetch the desired agent count and environment width
               AGENT_COUNT = FLAMEGPU.environment.getPropertyUInt("AGENT_COUNT")
@@ -1225,7 +1225,7 @@ If you have followed the complete tutorial, you should now have the following co
       model.addExecutionRoot(out_fn)
       model.generateLayers()
 
-      model.addInitFunctionCallback(create_agents())
+      model.addInitFunction(create_agents())
 
       # Specify the desired StepLoggingConfig
       step_log_cfg = pyflamegpu.StepLoggingConfig(model)
@@ -1366,7 +1366,7 @@ If you have followed the complete tutorial, you should now have the following co
     model.addRoot(out_fn)
     model.generateLayers()
 
-    class create_agents(pyflamegpu.HostFunctionCallback):
+    class create_agents(pyflamegpu.HostFunction):
         def run(self, FLAMEGPU):
             # Fetch the desired agent count and environment width
             AGENT_COUNT = FLAMEGPU.environment.getPropertyUInt("AGENT_COUNT")
@@ -1378,7 +1378,7 @@ If you have followed the complete tutorial, you should now have the following co
                 t.setVariableFloat("x", FLAMEGPU.random.uniformFloat() * ENV_WIDTH)
                 t.setVariableFloat("y", FLAMEGPU.random.uniformFloat() * ENV_WIDTH)
                 
-    model.addInitFunctionCallback(create_agents())
+    model.addInitFunction(create_agents())
 
     # Specify the desired StepLoggingConfig
     step_log_cfg = pyflamegpu.StepLoggingConfig(model)


### PR DESCRIPTION
Relates https://github.com/FLAMEGPU/FLAMEGPU2/pull/997