### PR TITLE
Add section about supported types to first chapter

### DIFF
--- a/src/guide/agent-functions/defining-agent-functions.rst
+++ b/src/guide/agent-functions/defining-agent-functions.rst
@@ -266,6 +266,7 @@ Host Device functions are not currently supported by the Python agent function f
     
 Related Links
 -------------
+* User Guide Section: :ref:`Supported Types<Supported Types>`
 * Full API documentation for :class:`AgentFunctionDescription<flamegpu::AgentFunctionDescription>`
 * Full API documentation for :c:macro:`FLAMEGPU_AGENT_FUNCTION`
 * Full API documentation for :c:macro:`FLAMEGPU_DEVICE_FUNCTION`

--- a/src/guide/creating-a-model/index.rst
+++ b/src/guide/creating-a-model/index.rst
@@ -69,3 +69,39 @@ The :class:`ModelDescription<flamegpu::ModelDescription>` class has various meth
     :func:`newMessage()<flamegpu::ModelDescription::newMessage>` take a template argument, so it is called in the format ``newMessage<flamegpu::MessageBruteForce>()``. As the Python API lacks templates, they are instead called in the format ``newMessageBruteForce()``.
 
 The subsequent chapters of this guide explore their usage in greater detail.
+
+.. _Supported Types:
+
+Supported Types
+^^^^^^^^^^^^^^^
+
+As FLAME GPU 2 is a C++ library, variable/property types within models must be specified. Throughout the API many methods rely on C++ templates where the type of a variable or property must be provided. If using the Python API the type is instead appended as a suffix to the method's identifier.
+
+Only primitive numeric types are currently supported, the full list of supported types is provided below.
+
+====================================== ===============================================
+C++ Template type                      Python Type Suffix
+====================================== ===============================================
+``char`` [1]_                          ``Char`` [1]_
+``signed char`` ``int8_t``             ``Int8``
+``unsigned char`` ``uint8_t``          ``UChar`` ``UInt8``
+``signed short`` ``int16_t`` ``short`` ``Int16``
+``unsigned short`` ``uint16_t``        ``UInt16``
+``signed int`` ``int32_t`` ``int``     ``Int32`` ``Int``
+``unsigned int`` ``uint32_t``          ``UInt32`` ``UInt``
+``int64_t`` [2]_                       ``Int64``
+``uint64_t`` [2]_                      ``UInt64``
+``float``                              ``Float``
+``double``                             ``Double``
+:type:`flamegpu::id_t` [3]_            ``ID`` [3]_
+====================================== ===============================================
+
+The subsequent chapters introduce all the relevant methods.
+
+.. note::
+  
+    If a boolean variable is required, a character type should be used.
+    
+.. [1] Within C++ ``char`` is is distinct from both ``signed char`` and ``unsigned char``.
+.. [2] ``long`` / ``long long`` type names are supported, however the corresponding integer length differs between compilers.
+.. [3] FLAME GPUs ID type is currently a 32 bit unsigned integer (``uint32_t`` / ``UInt32``).

--- a/src/guide/defining-agents/index.rst
+++ b/src/guide/defining-agents/index.rst
@@ -27,6 +27,8 @@ Agent Variables
 Agent variables should be used to store data which is unique to each instance of an agent, for example, each individual predator in a predator-prey simulation
 would have its own position and hunger level. Each variable has a name, type, default value and may take the form of a scalar or array.
 
+For a full list of supported types, see :ref:`Supported Types<Supported Types>`.
+
 Agent ID
 --------
 
@@ -94,6 +96,7 @@ States can be defined through the :class:`AgentDescription<flamegpu::AgentDescri
 Related Links
 ^^^^^^^^^^^^^
 
+* User Guide Section: :ref:`Supported Types<Supported Types>`
 * User Guide Chapter: :ref:`Agent Functions<Agent Functions>`
 * User Guide Page: :ref:`Agent Operations<Host Agent Operations>` (Host Functions)
 * Full API documentation for :class:`AgentDescription<flamegpu::AgentDescription>`

--- a/src/guide/environment/index.rst
+++ b/src/guide/environment/index.rst
@@ -45,6 +45,8 @@ Environment properties are declared using the :func:`newProperty()<template<type
 
 The type, name and initial value of the property are all specified, array properties additionally require the length of the array to be specified.
 
+For a full list of supported types, see :ref:`Supported Types<Supported Types>`.
+
 .. tabs::
 
   .. code-tab:: cpp C++
@@ -103,6 +105,7 @@ The type, dimensions and name of the macro property are all specified. The macro
 Related Links
 ^^^^^^^^^^^^^
 
+* User Guide Section: :ref:`Supported Types<Supported Types>`
 * User Guide Page: :ref:`Accessing the Environment<device environment>` (Agent Functions)
 * User Guide Page: :ref:`Accessing the Environment<host environment>` (Host Functions & Conditions)
 * User Guide Page: :ref:`Overriding the Initial Environment<RunPlan>`


### PR DESCRIPTION
I'm not the biggest fan of the location of this new section, but it feels like it needs to be really early, e.g. before environment/agent properties/variables.

*Found out that RST supports footnotes which is cool.*

Closes #51