### PR TITLE
Publish: don't keep history in gh-pages branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,3 +72,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: FLAMEGPU2-docs/build/userguide/
         cname: docs.flamegpu.com
+        force_orphan: true


### PR DESCRIPTION
This commit changes the publication action to use orphaned branches for the gh-pages commit / push. I.e. old gh-pages history gets deleted on push, which should lighten the repository when cloned.

Via https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan~

Closes #143