### PR TITLE
Fix variable name and message type

### DIFF
--- a/src/guide/agent-functions/agent-communication.rst
+++ b/src/guide/agent-functions/agent-communication.rst
@@ -106,7 +106,7 @@ When outputting bucket messages, the bucket index for the message must be set, u
 
       # Define an agent function, "outputdata" which has no input messages and outputs a message using the "MessageBucket" communication strategy
       @pyflamegpu.agent_function
-      def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageBruteForce):
+      def outputdata(message_in: pyflamegpu.MessageNone, message_out: pyflamegpu.MessageBucket):
           pyflamegpu.message_out.setVariableFloat("x", pyflamegpu.getVariableFloat("x"))
           # Set the bucket key for the message, to the agents "bucket" member variable
           pyflamegpu.message_out.setKey(pyflamegpu.getVariableInt("bucket"))

--- a/src/guide/host-functions/agent-operations.rst
+++ b/src/guide/host-functions/agent-operations.rst
@@ -182,7 +182,7 @@ It's also possible to create new agents with the :class:`HostAgentAPI<flamegpu::
 
         // Create 10 new 'sheep' agents
         for (int i = 0; i < 10; ++i) {
-            flamegpu::HostNewAgentAPI new_sheep = t.newAgent();
+            flamegpu::HostNewAgentAPI new_sheep = sheep.newAgent();
             new_sheep.setVariable<int>("awake", 1);
             new_sheep.setVariable<float>("health", 100.0f - i);
             new_sheep.setVariable<int, 3>("genes", {12, 2, 45});
@@ -198,7 +198,7 @@ It's also possible to create new agents with the :class:`HostAgentAPI<flamegpu::
         
         # Create 10 new 'sheep' agents
         for i in range(10):
-            new_sheep = t.newAgent()
+            new_sheep = sheep.newAgent()
             new_sheep.setVariableInt("awake", 1)
             new_sheep.setVariableFloat("health", 100 - i)
             new_sheep.setVariableArrayInt("genes", [12, 2, 45])


### PR DESCRIPTION
Quick fix for variable name in the examples (t instead of sheep) and message type (MessageBruteForce where MessageBucket was to be used) 