### PR TITLE
BugFix: CI was not building API docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,8 @@ jobs:
       working-directory: FLAMEGPU2-docs
       run: |
         source .venv/bin/activate
-        cmake . -B build -DFLAMEGPU_DOCS_WARNINGS_AS_ERRORS=${{ env.werror }}
+        cmake . -B build -DFLAMEGPU_DOCS_WARNINGS_AS_ERRORS=${{ env.werror }} -DFLAMEGPU_BUILD_API_DOCUMENTATION=${{ env.build_api_docs }}
+        
 
     - name: Build
       working-directory: FLAMEGPU2-docs/build


### PR DESCRIPTION
*Unclear when this was introduced, I assume the default argument changed from `ON` to `OFF` but nothing obvious stands out from git blame.*

Closes #172

-------

`Build API 3.x` action now includes the compilation output `[  1%] Generate API documentation for api_docs_xml` and takes much longer with all the `writing output... [ 27%] api/define_HostAgentAPI_8cuh_1a64629b6c7aa246731d1657c3ad70996a` lines.

API artifacts are now [~40mb compared to 4mb](https://github.com/FLAMEGPU/FLAMEGPU2-docs/actions/runs/6875546919?pr=173), and downloading one showed the API pages present.