### PR TITLE
Enable FLAMEGPU_BUILD_API_DOCUMENTATION in publish CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       working-directory: FLAMEGPU2-docs
       run: |
         source .venv/bin/activate
-        cmake . -B build
+        cmake . -B build -DFLAMEGPU_BUILD_API_DOCUMENTATION=${{ env.build_api_docs }}
 
     # Build the documentation
     - name: Build


### PR DESCRIPTION
Complements #173 and actually fixes the published cI build